### PR TITLE
Added check for None type in pooled normals resolution

### DIFF
--- a/beagle_etl/jobs/lims_etl_jobs.py
+++ b/beagle_etl/jobs/lims_etl_jobs.py
@@ -103,7 +103,7 @@ def fetch_samples(request_id, import_pooled_normals=True, import_samples=True):
         "piEmail": response_body["piEmail"],
     }
     pooled_normals = response_body.get("pooledNormals", [])
-    if import_pooled_normals:
+    if import_pooled_normals and pooled_normals:
         for f in pooled_normals:
             job = get_or_create_pooled_normal_job(f)
             children.add(str(job.id))


### PR DESCRIPTION
I was still getting errors on my local box, even with the change [here](https://github.com/mskcc/beagle/blob/develop/beagle_etl/jobs/lims_etl_jobs.py#L105).

This was happening when I did a couple import requests, like `10058_B`. 