### PR TITLE
Copy outputs operator fixes

### DIFF
--- a/runner/operator/copy_outputs_operator/construct_copy_outputs.py
+++ b/runner/operator/copy_outputs_operator/construct_copy_outputs.py
@@ -46,7 +46,7 @@ def get_roslin_output_description():
 
 
 def create_cwl_file_obj(file_path):
-    cwl_file_obj = {'class': 'File', 'path': file_path}
+    cwl_file_obj = {'class': 'File', 'location': "juno://%s" % file_path}
     return cwl_file_obj
 
 
@@ -84,13 +84,6 @@ def list_file_paths(file_obj_list):
         list_of_files = list_of_files + single_file_obj['secondary_files']
     return list_of_files
 
-
-def list_file_paths(file_obj_list):
-    list_of_files = []
-    for single_file_obj in file_obj_list:
-        list_of_files = list_of_files + single_file_obj['files']
-        list_of_files = list_of_files + single_file_obj['secondary_files']
-    return list_of_files
 
 
 def construct_copy_outputs_input(run_id_list):

--- a/runner/operator/copy_outputs_operator/construct_copy_outputs.py
+++ b/runner/operator/copy_outputs_operator/construct_copy_outputs.py
@@ -7,7 +7,8 @@ from runner.models import Port
 
 
 def get_roslin_output_description():
-    output_description = {'bams': 'bam',
+    output_description = {'normal_bam': 'bam',
+                          'tumor_bam': 'bam',
                           'clstats1': 'qc',
                           'clstats2': 'qc',
                           'md_metrics': 'qc',
@@ -83,7 +84,6 @@ def list_file_paths(file_obj_list):
         list_of_files = list_of_files + single_file_obj['files']
         list_of_files = list_of_files + single_file_obj['secondary_files']
     return list_of_files
-
 
 
 def construct_copy_outputs_input(run_id_list):

--- a/runner/operator/copy_outputs_operator/copy_outputs_operator.py
+++ b/runner/operator/copy_outputs_operator/copy_outputs_operator.py
@@ -14,6 +14,6 @@ class CopyOutputsOperator(Operator):
             number_of_runs, run_ids[0])
         copy_outputs_job_data = {
             'app': self.get_pipeline_id(), 'inputs': input_json, 'name': name}
-        copy_outputs_job = (APIRunCreateSerializer(
-            data=copy_outputs_job_data), input_json)
+        copy_outputs_job = [(APIRunCreateSerializer(
+            data=copy_outputs_job_data), input_json)]
         return copy_outputs_job

--- a/runner/run/processors/port_processor.py
+++ b/runner/run/processors/port_processor.py
@@ -156,21 +156,20 @@ class PortProcessor(object):
             file_obj_db = FileProcessor.create_file_obj(uri, size, group_id, metadata)
         except FileConflictException as e:
             logger.warning(str(e))
+            file_obj_db = FileProcessor.get_file_obj(uri)
             # TODO: Check what to do in case file already exist in DB. Note: This should never happen
             # raise PortProcessorException(e)
-        else:
-            secondary_files = file_obj.pop('secondaryFiles', [])
-            secondary_file_list = []
-            secondary_files_obj = PortProcessor.process_files(secondary_files,
-                                                              PortAction.REGISTER_OUTPUT_FILES,
-                                                              group_id=group_id,
-                                                              metadata=metadata,
-                                                              file_list=secondary_file_list)
-            if secondary_files_obj:
-                file_obj['secondaryFiles'] = secondary_files_obj
-            file_obj['location'] = FileProcessor.get_bid_from_file(file_obj_db)
-            if file_list is not None:
-                file_list.append('bid://%s' % FileProcessor.get_bid_from_file(file_obj_db))
-                file_list.extend([f['location'] for f in secondary_files_obj])
-                return file_obj
+        secondary_files = file_obj.pop('secondaryFiles', [])
+        secondary_file_list = []
+        secondary_files_obj = PortProcessor.process_files(secondary_files,
+                                                          PortAction.REGISTER_OUTPUT_FILES,
+                                                          group_id=group_id,
+                                                          metadata=metadata,
+                                                          file_list=secondary_file_list)
+        if secondary_files_obj:
+            file_obj['secondaryFiles'] = secondary_files_obj
+        file_obj['location'] = FileProcessor.get_bid_from_file(file_obj_db)
+        if file_list is not None:
+            file_list.append('bid://%s' % FileProcessor.get_bid_from_file(file_obj_db))
+            file_list.extend([f['location'] for f in secondary_files_obj])
         return file_obj

--- a/runner/serializers.py
+++ b/runner/serializers.py
@@ -155,7 +155,10 @@ class APIRunCreateSerializer(serializers.Serializer):
 
 class RequestIdOperatorSerializer(serializers.Serializer):
     request_ids = serializers.ListField(
-        child=serializers.CharField(max_length=30)
+        child=serializers.CharField(max_length=30), allow_empty=True
+    )
+    run_ids = serializers.ListField(
+        child=serializers.UUIDField(), allow_empty=True
     )
     pipeline_name = serializers.CharField(max_length=100)
 

--- a/runner/tasks.py
+++ b/runner/tasks.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 def create_jobs_from_operator(operator):
     jobs = operator.get_jobs()
-    # trigger = OperatorTrigger.objects.filter(from_operator=operator).first()
 
     valid_jobs, invalid_jobs = [], []
     for job in jobs:

--- a/runner/tests/operator/copy_outputs_operator/test_copy_outputs_operator.py
+++ b/runner/tests/operator/copy_outputs_operator/test_copy_outputs_operator.py
@@ -27,8 +27,8 @@ class TestCopyOutputs(TestCase):
         os.environ['TMPDIR'] = ''
 
     def check_if_file_obj_valid(self, file_obj):
-        if 'class' in file_obj and 'path' in file_obj:
-            if file_obj['class'] == 'File' and type(file_obj['path']) == str:
+        if 'class' in file_obj and 'location' in file_obj:
+            if file_obj['class'] == 'File' and type(file_obj['location']) == str:
                 return True
         return False
 
@@ -71,7 +71,7 @@ class TestCopyOutputs(TestCase):
         operator = OperatorFactory.get_by_model(
             operator_model,  run_ids=["ca18b090-03ad-4bef-acd3-52600f8e62eb"])
         input_json_valid = False
-        if operator.get_jobs()[0].is_valid():
-            input_json = operator.get_jobs()[0].initial_data['inputs']
+        if operator.get_jobs()[0][0].is_valid():
+            input_json = operator.get_jobs()[0][0].initial_data['inputs']
             input_json_valid = self.validate_copy_outputs_input(input_json)
         self.assertEqual(input_json_valid, True)

--- a/runner/views/run_api_view.py
+++ b/runner/views/run_api_view.py
@@ -97,13 +97,14 @@ class OperatorViewSet(GenericAPIView):
         pipeline_name = request.data['pipeline_name']
         pipeline = get_object_or_404(Pipeline, name=pipeline_name)
 
-        for request_id in request_ids:
-            logging.info("Submitting requestId %s to pipeline %s" % (request_id, pipeline_name))
-            create_jobs_from_request.delay(request_id, pipeline.operator_id)
-
-        operator_model = Operator.objects.get(id=pipeline.operator_id)
-        operator = OperatorFactory.get_by_model(operator_model, run_ids=run_ids)
-        create_jobs_from_operator(operator)
+        if request_ids:
+            for request_id in request_ids:
+                logging.info("Submitting requestId %s to pipeline %s" % (request_id, pipeline_name))
+                create_jobs_from_request.delay(request_id, pipeline.operator_id)
+        else:
+            operator_model = Operator.objects.get(id=pipeline.operator_id)
+            operator = OperatorFactory.get_by_model(operator_model, run_ids=run_ids)
+            create_jobs_from_operator(operator)
         # tempo_operator = TempoOperator(request_id)
         # jobs = tempo_operator.get_jobs()
         # result = []
@@ -111,7 +112,7 @@ class OperatorViewSet(GenericAPIView):
         #     if job.is_valid():
         #         run = job.save()
         #         result.append(run)
-        return Response({"details": "Operator Job submitted %s" % str(request_ids)}, status=status.HTTP_200_OK)
+        return Response({"details": "Operator Job submitted to %s" % str(pipeline_name)}, status=status.HTTP_200_OK)
 
 
 class OperatorErrorViewSet(mixins.ListModelMixin,

--- a/runner/views/run_api_view.py
+++ b/runner/views/run_api_view.py
@@ -101,10 +101,12 @@ class OperatorViewSet(GenericAPIView):
             for request_id in request_ids:
                 logging.info("Submitting requestId %s to pipeline %s" % (request_id, pipeline_name))
                 create_jobs_from_request.delay(request_id, pipeline.operator_id)
+            body = {"details": "Operator Job submitted %s" % str(request_ids)}
         else:
             operator_model = Operator.objects.get(id=pipeline.operator_id)
             operator = OperatorFactory.get_by_model(operator_model, run_ids=run_ids)
             create_jobs_from_operator(operator)
+            body = {"details": "Operator Job submitted to pipeline %s with runs %s" % (pipeline_name, str(run_ids))}
         # tempo_operator = TempoOperator(request_id)
         # jobs = tempo_operator.get_jobs()
         # result = []
@@ -112,7 +114,7 @@ class OperatorViewSet(GenericAPIView):
         #     if job.is_valid():
         #         run = job.save()
         #         result.append(run)
-        return Response({"details": "Operator Job submitted to %s" % str(pipeline_name)}, status=status.HTTP_200_OK)
+        return Response(body, status=status.HTTP_200_OK)
 
 
 class OperatorErrorViewSet(mixins.ListModelMixin,


### PR DESCRIPTION
- Use latest version of roslin when creating inputs for copy outputs with `normal_bam` and `tumor_bam` instead of `bams` (@nikhil please check this)
- Fix that operator returns a list of jobs, instead one job
- Change API endpoint so we can run operator based on requestId  + pipeline or runs + pipeline