### PR TITLE
Feature/etc add other contact emails

### DIFF
--- a/beagle_etl/jobs/lims_etl_jobs.py
+++ b/beagle_etl/jobs/lims_etl_jobs.py
@@ -440,6 +440,7 @@ def update_metadata(request_id):
         "investigatorName": response_body['investigatorName'],
         "labHeadEmail": response_body['labHeadEmail'],
         "labHeadName": response_body['labHeadName'],
+        "otherContactEmails": response_body['otherContactEmails'],
         "projectManagerName": response_body['projectManagerName'],
         "recipe": response_body['recipe'],
         "piEmail": response_body["piEmail"],

--- a/beagle_etl/jobs/lims_etl_jobs.py
+++ b/beagle_etl/jobs/lims_etl_jobs.py
@@ -119,6 +119,7 @@ def fetch_samples(request_id, import_pooled_normals=True, import_samples=True, j
         "investigatorName": response_body['investigatorName'],
         "labHeadEmail": response_body['labHeadEmail'],
         "labHeadName": response_body['labHeadName'],
+        "otherContactEmails": response_body['otherContactEmails'],
         "projectManagerName": response_body['projectManagerName'],
         "recipe": response_body['recipe'],
         "piEmail": response_body["piEmail"],

--- a/file_system/metadata/validator.py
+++ b/file_system/metadata/validator.py
@@ -55,6 +55,9 @@ METADATA_SCHEMA = {
                 "labHeadName": {
                     "type": "string"
                 },
+                "otherContactEmails": {
+                    "type": "string"
+                },
                 "projectManagerName": {
                     "type": "string"
                 }

--- a/runner/operator/roslin_operator/bin/make_sample.py
+++ b/runner/operator/roslin_operator/bin/make_sample.py
@@ -22,10 +22,10 @@ def remove_with_caveats(samples):
         patient_id = sample['patient_id']
         if sample_name == 'sampleNameMalformed':
             add = False
-            LOGGER.debug("Sample name is malformed for for %s; removing from set", sample_id)
+            LOGGER.info("Sample name is malformed for for %s; removing from set", sample_id)
         if patient_id[:2].lower() not in 'c-':
             add = False
-            LOGGER.debug(
+            LOGGER.info(
                 "Patient ID does not start with expected 'C-' prefix for %s; removing from set",
                 sample_id)
         if add:
@@ -167,9 +167,9 @@ def build_sample(data, ignore_sample_formatting=False):
         try:
             rg_id = '_'.join([cmo_sample_name, platform_unit])
         except:
-            LOGGER.error("RG ID couldn't be set.")
-            LOGGER.error("Sample ID %s; patient ID %s", sample_id, cmo_patient_id)
-            LOGGER.error("SampleName %s; platform unit %s", cmo_sample_name, platform_unit)
+            LOGGER.info("RG ID couldn't be set.")
+            LOGGER.info("Sample ID %s; patient ID %s", sample_id, cmo_patient_id)
+            LOGGER.info("SampleName %s; platform unit %s", cmo_sample_name, platform_unit)
         if rg_id not in samples:
             samples[rg_id] = dict()
             sample = dict()

--- a/runner/operator/roslin_operator/bin/make_sample.py
+++ b/runner/operator/roslin_operator/bin/make_sample.py
@@ -149,6 +149,8 @@ def build_sample(data, ignore_sample_formatting=False):
         specimen_type = meta['specimenType']
         species = meta['species']
         cmo_sample_name = format_sample_name(meta['sampleName'], ignore_sample_formatting)
+        if cmo_sample_name == "sampleNameMalformed":
+            LOGGER.error("sampleName for %s is malformed", sample_id)
         flowcell_id = meta['flowCellId']
         barcode_index = meta['barcodeIndex']
         cmo_patient_id = meta['patientId']
@@ -159,9 +161,15 @@ def build_sample(data, ignore_sample_formatting=False):
         pi_email = meta['labHeadEmail']
         run_id = meta['runId']
         preservation_type = meta['preservation']
+        rg_id = cmo_sample_name + "_1"
         if barcode_index:
             platform_unit = '_'.join([flowcell_id, barcode_index])
-        rg_id = '_'.join([cmo_sample_name, platform_unit])
+        try:
+            rg_id = '_'.join([cmo_sample_name, platform_unit])
+        except:
+            LOGGER.error("RG ID couldn't be set.")
+            LOGGER.error("Sample ID %s; patient ID %s", sample_id, cmo_patient_id)
+            LOGGER.error("SampleName %s; platform unit %s", cmo_sample_name, platform_unit)
         if rg_id not in samples:
             samples[rg_id] = dict()
             sample = dict()

--- a/runner/operator/roslin_operator/bin/pair_request.py
+++ b/runner/operator/roslin_operator/bin/pair_request.py
@@ -81,6 +81,7 @@ def compile_pairs(samples):
         LOGGER.error("Returning an empty list of pairs.")
 
     for tumor in tumors:
+        LOGGER.info("Pairing tumor sample %s", tumor['sample_id'])
         patient_id = tumor['patient_id']
         if patient_id:
             bait_set = tumor['bait_set']
@@ -88,20 +89,23 @@ def compile_pairs(samples):
             preservation_types = tumor['preservation_type']
             normal = get_viable_normal(normals, patient_id, bait_set)
             if normal:
+                LOGGER.info("Pairing %s with %s", tumor['sample_id'], normal['sample_id'])
                 pairs['tumor'].append(tumor)
                 pairs['normal'].append(normal)
             else:
-                LOGGER.debug("Missing normal for sample %s; querying patient %s", tumor['sample_id'], patient_id)
+                LOGGER.info("Missing normal for sample %s; querying patient %s", tumor['sample_id'], patient_id)
                 patient_samples = get_samples_from_patient_id(patient_id)
                 new_normals = get_by_tumor_type(patient_samples, "Normal")
                 new_normal = get_viable_normal(new_normals, patient_id, bait_set)
                 if new_normal:
+                    LOGGER.info("Pairing %s with %s", tumor['sample_id'], new_normal['sample_id'])
                     pairs['tumor'].append(tumor)
                     pairs['normal'].append(new_normal)
                 else:
                     pooled_normal = get_pooled_normals(run_ids, preservation_types, bait_set)
-                    LOGGER.debug("Checking for Pooled Normal")
+                    LOGGER.info("No normal found for patient %s; checking for Pooled Normal", patient_id)
                     if pooled_normal:
+                        LOGGER.info("Pairing %s with %s", tumor['sample_id'], pooled_normal['sample_id'])
                         pairs['tumor'].append(tumor)
                         pairs['normal'].append(pooled_normal)
                     else:

--- a/runner/operator/roslin_operator/bin/pair_request.py
+++ b/runner/operator/roslin_operator/bin/pair_request.py
@@ -89,29 +89,50 @@ def compile_pairs(samples):
             preservation_types = tumor['preservation_type']
             normal = get_viable_normal(normals, patient_id, bait_set)
             if normal:
-                LOGGER.info("Pairing %s with %s", tumor['sample_id'], normal['sample_id'])
+                LOGGER.info("Pairing %s (%s) with %s (%s)",
+                            tumor['sample_id'],
+                            tumor['SM'],
+                            normal['sample_id'],
+                            normal['SM'])
                 pairs['tumor'].append(tumor)
                 pairs['normal'].append(normal)
             else:
-                LOGGER.info("Missing normal for sample %s; querying patient %s", tumor['sample_id'], patient_id)
+                LOGGER.info("Missing normal for sample %s (%s); querying patient %s",
+                            tumor['sample_id'],
+                            tumor['SM'],
+                            patient_id)
                 patient_samples = get_samples_from_patient_id(patient_id)
                 new_normals = get_by_tumor_type(patient_samples, "Normal")
                 new_normal = get_viable_normal(new_normals, patient_id, bait_set)
                 if new_normal:
-                    LOGGER.info("Pairing %s with %s", tumor['sample_id'], new_normal['sample_id'])
+                    LOGGER.info("Pairing %s (%s) with %s (%s)",
+                                tumor['sample_id'],
+                                tumor['SM'],
+                                new_normal['sample_id'],
+                                new_normal['SM'])
                     pairs['tumor'].append(tumor)
                     pairs['normal'].append(new_normal)
                 else:
                     pooled_normal = get_pooled_normals(run_ids, preservation_types, bait_set)
-                    LOGGER.info("No normal found for patient %s; checking for Pooled Normal", patient_id)
+                    LOGGER.info("No normal found for patient %s; checking for Pooled Normal",
+                                patient_id)
                     if pooled_normal:
-                        LOGGER.info("Pairing %s with %s", tumor['sample_id'], pooled_normal['sample_id'])
+                        LOGGER.info("Pairing %s (%s) with %s (%s)",
+                                    tumor['sample_id'],
+                                    tumor['SM'],
+                                    pooled_normal['sample_id'],
+                                    pooled_normal['SM'])
                         pairs['tumor'].append(tumor)
                         pairs['normal'].append(pooled_normal)
                     else:
-                        LOGGER.error("No normal found for %s, patient %s", tumor['sample_id'], patient_id)
+                        LOGGER.error("No normal found for %s (%s), patient %s",
+                                     tumor['sample_id'],
+                                     tumor['SM'],
+                                     patient_id)
         else:
-            LOGGER.error("NoPatientIdError: No patient_id found for %s; skipping.", tumor['sample_id'])
+            LOGGER.error("NoPatientIdError: No patient_id found for %s (%s); skipping.",
+                         tumor['sample_id'],
+                         tumor['SM'])
     return pairs
 
 

--- a/runner/operator/roslin_operator/bin/retrieve_samples_by_query.py
+++ b/runner/operator/roslin_operator/bin/retrieve_samples_by_query.py
@@ -83,19 +83,15 @@ def build_run_id_query(data):
 
 def build_preservation_query(data):
     """
-    Build complex Q object preservation type query from given data
+    Build simple query for either FROZEN or FFPE pooled normal
 
-    Only does OR queries, as seen in line
-
-       query |= item
-
-    Very similar to build_run_id_query, but "filemetadata__metadata__preservation"
-    can't be sent as a value, so had to make a semi-redundant function
+    Main logic: if FFPE in data, return FFPE query; else, return FROZEN query
     """
-    data_query_set = [Q(filemetadata__metadata__preservation=value) for value in set(data)]
-    query = data_query_set.pop()
-    for item in data_query_set:
-        query |= item
+    preservations_lower_case = set([x.lower() for x in data])
+    value = "FROZEN"
+    if "ffpe" in preservations_lower_case:
+        value = "FFPE"
+    query = Q(filemetadata__metadata__preservation=value)
     return query
 
 
@@ -125,7 +121,7 @@ def get_pooled_normals(run_ids, preservation_types, bait_set):
     # arbitrarily named
     sample_name = "pooled_normal_%s_%s_%s" % (descriptor,
                                               "_".join(run_ids),
-                                              "_".join(preservation_types))
+                                              "_".join(set(preservation_types)))
 
     num_of_pooled_normals = len(pooled_normals)
     if num_of_pooled_normals > 0:

--- a/runner/tests/operator/roslin_operator/test_pair_request.py
+++ b/runner/tests/operator/roslin_operator/test_pair_request.py
@@ -86,23 +86,25 @@ class TestPairRequest(TestCase):
         "bait_set": "IMPACT468_BAITS",
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
-        "tumor_type": "Normal"
+        "tumor_type": "Normal",
+        "sample_id": "my_sample_id1"
         },
         {
         "patient_id": "C-W86LMR",
         "bait_set": "IMPACT468_BAITS",
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
-        "tumor_type": "Tumor"
+        "tumor_type": "Tumor",
+        "sample_id": "my_sample_id2"
         }
         ]
         pairs = compile_pairs(samples)
         expected_pairs = {
         'tumor': [
-        {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]}
+        {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1"}
         ],
         'normal': [
-        {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]}
+        {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]", sample_id": "my_sample_id2" }
         ]
         }
         self.assertTrue(pairs == expected_pairs)
@@ -117,44 +119,53 @@ class TestPairRequest(TestCase):
         "patient_id": "C-DRKHP7",
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
-        "tumor_type": "Normal"
+        "tumor_type": "Normal",
+        "sample_id": "my_sample_id1"
         },
         {
         "bait_set": "IMPACT468_BAITS",
         "patient_id": "C-8VK0V7",
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
-        "tumor_type": "Normal"
+        "tumor_type": "Normal",
+        "sample_id": "my_sample_id2"
         },
         {
         "bait_set": "IMPACT468_BAITS",
         "patient_id": "C-DRKHP7",
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
-        "tumor_type": "Tumor"
+        "tumor_type": "Tumor",
+        "sample_id": "my_sample_id3"
         },
         {
         "bait_set": "IMPACT468_BAITS",
         "patient_id": "C-8VK0V7",
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
-        "tumor_type": "Tumor"
+        "tumor_type": "Tumor",
+        "sample_id": "my_sample_id4"
         },
         {
         "bait_set": "IMPACT468_BAITS",
         "patient_id": "C-DRKHP7",
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
-        "tumor_type": "Tumor"
+        "tumor_type": "Tumor",
+        "sample_id": "my_sample_id5"
         }
         ]
         pairs = compile_pairs(samples)
         expected_pairs = {
         'tumor': [
-        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]}, {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-8VK0V7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]}, {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]}
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id3"}
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-8VK0V7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id4"},
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id5"}
         ],
         'normal': [
-        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]}, {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-8VK0V7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]}, {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]}
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1"},
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-8VK0V7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id2"},
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1"}
         ]
         }
         self.assertTrue(pairs == expected_pairs)

--- a/runner/tests/operator/roslin_operator/test_pair_request.py
+++ b/runner/tests/operator/roslin_operator/test_pair_request.py
@@ -357,6 +357,7 @@ class TestPairRequest(TestCase):
         'run_id': ['JAX_0397'],
         "preservation_type": ["EDTA-Streck"],
         "sample_id": "10075_D_3_5",
+        "SM": "10075_D_3_5",
         "request_id": "10075_D_3"
         }
         ]
@@ -371,6 +372,7 @@ class TestPairRequest(TestCase):
             "preservation_type": ["EDTA-Streck"],
             'tumor_type': 'Tumor',
             'sample_id': '10075_D_3_5',
+            "SM": "10075_D_3_5",
             'request_id': '10075_D_3'
             }
         ],
@@ -435,6 +437,7 @@ class TestPairRequest(TestCase):
         "patient_id": "C-8VK0V7",
         "tumor_type": "Tumor",
         "sample_id": "10075_D_3_5",
+        "SM": "10075_D_3_5",
         "request_id": "10075_D_3",
         'run_id': ['JAX_0397'],
         "preservation_type": ["EDTA-Streck"]
@@ -449,6 +452,7 @@ class TestPairRequest(TestCase):
             'patient_id': 'C-8VK0V7',
             'tumor_type': 'Tumor',
             'sample_id': '10075_D_3_5',
+            "SM": "10075_D_3_5",
             'request_id': '10075_D_3',
             'run_id': ['JAX_0397'],
             "preservation_type": ["EDTA-Streck"]

--- a/runner/tests/operator/roslin_operator/test_pair_request.py
+++ b/runner/tests/operator/roslin_operator/test_pair_request.py
@@ -289,7 +289,7 @@ class TestPairRequest(TestCase):
         "tumor_type": "Tumor",
         'run_id': ['JAX_0397'],
         "preservation_type": ["Frozen"],
-        "SM": "10075_D_1"
+        "SM": "10075_D_1",
         "sample_id": "10075_D_1"
         }
         ]

--- a/runner/tests/operator/roslin_operator/test_pair_request.py
+++ b/runner/tests/operator/roslin_operator/test_pair_request.py
@@ -158,7 +158,7 @@ class TestPairRequest(TestCase):
         pairs = compile_pairs(samples)
         expected_pairs = {
         'tumor': [
-        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id3"}
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id3"},
         {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-8VK0V7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id4"},
         {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id5"}
         ],

--- a/runner/tests/operator/roslin_operator/test_pair_request.py
+++ b/runner/tests/operator/roslin_operator/test_pair_request.py
@@ -104,7 +104,7 @@ class TestPairRequest(TestCase):
         {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1"}
         ],
         'normal': [
-        {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"]", sample_id": "my_sample_id2" }
+        {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id2" }
         ]
         }
         self.assertTrue(pairs == expected_pairs)

--- a/runner/tests/operator/roslin_operator/test_pair_request.py
+++ b/runner/tests/operator/roslin_operator/test_pair_request.py
@@ -87,7 +87,8 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Normal",
-        "sample_id": "my_sample_id1"
+        "sample_id": "my_sample_id1",
+        "SM": "my_sample_id1"
         },
         {
         "patient_id": "C-W86LMR",
@@ -95,16 +96,17 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Tumor",
+        "SM": "my_sample_id2",
         "sample_id": "my_sample_id2"
         }
         ]
         pairs = compile_pairs(samples)
         expected_pairs = {
         'tumor': [
-        {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1"}
+            {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1", "SM": "my_sample_id1"}
         ],
         'normal': [
-        {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id2" }
+            {'patient_id': 'C-W86LMR', 'bait_set': 'IMPACT468_BAITS', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id2", "SM": "my_sample_id2" }
         ]
         }
         self.assertTrue(pairs == expected_pairs)
@@ -120,6 +122,7 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Normal",
+        "SM": "my_sample_id1",
         "sample_id": "my_sample_id1"
         },
         {
@@ -128,6 +131,7 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Normal",
+        "SM": "my_sample_id2",
         "sample_id": "my_sample_id2"
         },
         {
@@ -136,6 +140,7 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Tumor",
+        "SM": "my_sample_id3",
         "sample_id": "my_sample_id3"
         },
         {
@@ -144,6 +149,7 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Tumor",
+        "SM": "my_sample_id4",
         "sample_id": "my_sample_id4"
         },
         {
@@ -152,20 +158,21 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Tumor",
+        "SM": "my_sample_id5",
         "sample_id": "my_sample_id5"
         }
         ]
         pairs = compile_pairs(samples)
         expected_pairs = {
         'tumor': [
-        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id3"},
-        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-8VK0V7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id4"},
-        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id5"}
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id3", "SM": "my_sample_id3"},
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-8VK0V7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id4", "SM": "my_sample_id4"},
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Tumor', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id5", "SM": "my_sample_id5"}
         ],
         'normal': [
-        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1"},
-        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-8VK0V7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id2"},
-        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1"}
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1", "SM": "my_sample_id1"},
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-8VK0V7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id2", "SM": "my_sample_id2"},
+        {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1", "SM": "my_sample_id1"}
         ]
         }
         self.assertTrue(pairs == expected_pairs)
@@ -207,6 +214,7 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Tumor",
+        "SM": "10075_D_1",
         "sample_id": "10075_D_1"
         }
         ]
@@ -281,6 +289,7 @@ class TestPairRequest(TestCase):
         "tumor_type": "Tumor",
         'run_id': ['JAX_0397'],
         "preservation_type": ["Frozen"],
+        "SM": "10075_D_1"
         "sample_id": "10075_D_1"
         }
         ]
@@ -312,6 +321,7 @@ class TestPairRequest(TestCase):
         'tumor': [{
             'bait_set': 'IMPACT468_BAITS',
             'sample_id': '10075_D_1',
+            'SM': '10075_D_1',
             'patient_id': 'C-DRKHP7',
             'run_id': ['JAX_0397'],
             "preservation_type": ["Frozen"],

--- a/runner/tests/operator/roslin_operator/test_pair_request.py
+++ b/runner/tests/operator/roslin_operator/test_pair_request.py
@@ -87,8 +87,8 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Normal",
-        "sample_id": "my_sample_id1",
-        "SM": "my_sample_id1"
+        "sample_id": "my_sample_id2",
+        "SM": "my_sample_id2"
         },
         {
         "patient_id": "C-W86LMR",
@@ -96,8 +96,8 @@ class TestPairRequest(TestCase):
         "run_id": ["JAX_0397"],
         "preservation_type": ["Frozen"],
         "tumor_type": "Tumor",
-        "SM": "my_sample_id2",
-        "sample_id": "my_sample_id2"
+        "SM": "my_sample_id1",
+        "sample_id": "my_sample_id1"
         }
         ]
         pairs = compile_pairs(samples)

--- a/runner/tests/operator/roslin_operator/test_pair_request.py
+++ b/runner/tests/operator/roslin_operator/test_pair_request.py
@@ -175,6 +175,12 @@ class TestPairRequest(TestCase):
         {'bait_set': 'IMPACT468_BAITS', 'patient_id': 'C-DRKHP7', 'tumor_type': 'Normal', "run_id": ["JAX_0397"], "preservation_type": ["Frozen"], "sample_id": "my_sample_id1", "SM": "my_sample_id1"}
         ]
         }
+
+
+        print("Running test_compile_pairs2 ---")
+        print(json.dumps(pairs, cls=UUIDEncoder))
+        print(json.dumps(expected_pairs, cls=UUIDEncoder))
+
         self.assertTrue(pairs == expected_pairs)
 
     def test_compile_pairs3(self):
@@ -246,6 +252,7 @@ class TestPairRequest(TestCase):
         'tumor': [{
             'bait_set': 'IMPACT468_BAITS',
             'sample_id': '10075_D_1',
+            'SM': '10075_D_1',
             'patient_id': 'C-DRKHP7',
             "run_id": ["JAX_0397"],
             "preservation_type": ["Frozen"],


### PR DESCRIPTION
Small update to request metadata - adds `otherContactEmails` from recently changed IGOLIMS endpoint.

Has commits from https://github.com/mskcc/beagle/pull/198; review this after that one has been merged.