### PR TITLE
Removed setting of output directory by pipeline value so that 'None' logic triggers again

### DIFF
--- a/runner/serializers.py
+++ b/runner/serializers.py
@@ -144,11 +144,9 @@ class APIRunCreateSerializer(serializers.Serializer):
         tags = validated_data.get('tags')
         create_date = datetime.datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
         name = "Run %s: %s" % (pipeline.name, create_date)
-        output_directory = pipeline.output_directory
+        output_directory = validated_data.get('output_directory')
         if validated_data.get('name') is not None:
             name = validated_data.get('name') + ' (' + create_date + ')'
-        if validated_data.get('output_directory') is not None:
-            output_directory = validated_data.get('output_directory')
         run = Run(name=name,
                 app=pipeline,
                 status=RunStatus.CREATING,


### PR DESCRIPTION
Without this fix, the run ids weren't being appended in the roslin operator so they were writing to the same output directory