### PR TITLE
Add django extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,6 +341,9 @@ runserver: check-env
 MIGRATION_ARGS?=
 migrate: check-env
 	python manage.py migrate $(MIGRATION_ARGS)
+shell : check-env
+	python manage.py shell_plus --notebook
+
 
 dumpdata: check-env
 	python manage.py dumpdata

--- a/beagle/settings.py
+++ b/beagle/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_extensions',
     'rest_framework',
     'corsheaders',
     'drf_multiple_model',

--- a/file_system/admin.py
+++ b/file_system/admin.py
@@ -5,7 +5,7 @@ from .models import Storage, File, FileType, FileMetadata, FileGroup, FileGroupM
 
 
 class FileAdmin(admin.ModelAdmin):
-    list_display = ('id', 'file_name', 'size')
+    list_display = ('id', 'file_name', 'file_group', 'size')
     search_fields = ['file_name']
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ djangorestframework-simplejwt==4.3.0
 docopt==0.6.2
 pygments==2.5.2
 psycopg2-binary
-
+django-extensions==2.2.9


### PR DESCRIPTION
Feel free to close this but this helped when I was developing an operator: `django-extensions` -- https://django-extensions.readthedocs.io/en/latest/

Specifically `manage.py shell_plus`

There's also some model extensions that could be useful...
https://django-extensions.readthedocs.io/en/latest/field_extensions.html