### PR TITLE
Add recipe filter to jobs admin page

### DIFF
--- a/beagle_etl/admin.py
+++ b/beagle_etl/admin.py
@@ -1,4 +1,6 @@
+import os
 from django.contrib import admin
+from django.contrib.admin import ModelAdmin, SimpleListFilter
 from django.utils.safestring import mark_safe
 from .models import Job, JobStatus, Operator
 from lib.admin import pretty_python_exception, pretty_json
@@ -18,9 +20,26 @@ def restart(modeladmin, request, queryset):
 
 restart.short_description = "Restart"
 
+class RecipeFilter(SimpleListFilter):
+    title = 'Recipe'
+    parameter_name = 'recipe'
 
-class JobAdmin(admin.ModelAdmin):
-    list_display = ('id', 'run', 'retry_count',
+    def lookups(self, request, model_admin):
+        options = set()
+
+        for o in Operator.objects.values("recipes"):
+            for recipe in o["recipes"]:
+                options.add((recipe, recipe))
+        return options
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(args__request_metadata__recipe=self.value())
+        return queryset
+
+
+class JobAdmin(ModelAdmin):
+    list_display = ('id', 'get_short_run', 'retry_count',
                     pretty_json('args'),
                     'children',
                     'status',
@@ -31,8 +50,18 @@ class JobAdmin(admin.ModelAdmin):
     readonly_fields = ('message',)
     actions = (restart,)
     ordering = ('-created_date',)
+    list_filter = (RecipeFilter, )
 
-class OperatorAdmin(admin.ModelAdmin):
+    def get_short_run(self, obj):
+        if obj.run:
+            (_, run) = os.path.splitext(obj.run)
+            return mark_safe("<span title='%s'>%s</span>" % (obj.run, run[1:]))
+        else:
+            return '--'
+
+    get_short_run.short_description = 'Run'
+
+class OperatorAdmin(ModelAdmin):
     list_display = ('id', 'class_name', 'recipes', 'active')
 
 


### PR DESCRIPTION
I find myself searching for access jobs a lot on production, this would make that much easier.

<img width="1777" alt="Screen Shot 2020-05-07 at 15 07 32" src="https://user-images.githubusercontent.com/17934/81334733-7c0c2c00-9074-11ea-84b0-d28e455d775c.png">
