### PR TITLE
Improve list ETL jobs endpoint

### DIFF
--- a/beagle/pagination.py
+++ b/beagle/pagination.py
@@ -29,15 +29,15 @@ class BeaglePagination(PageNumberPagination):
 
 
 def time_filter(model, query_params):
-    if query_params.get('created_date.timedelta'):
-        time_threshold = datetime.now() - timedelta(hours=int(query_params['created_date.timedelta']))
+    if query_params.get('created_date_timedelta'):
+        time_threshold = datetime.now() - timedelta(hours=int(query_params['created_date_timedelta']))
         queryset = model.objects.filter(created_date__gt=time_threshold).order_by('-created_date')
-    elif query_params.get('created_date.gt') or query_params.get('created_date.lt'):
-        if query_params.get('created_date.gt'):
-            time_gt = datetime.fromtimestamp(int(query_params['created_date.gt']))
+    elif query_params.get('created_date_gt') or query_params.get('created_date_lt'):
+        if query_params.get('created_date_gt'):
+            time_gt = query_params['created_date_gt']
             queryset = model.objects.filter(created_date__gt=time_gt).order_by('-created_date')
-        if query_params.get('created_date.lt'):
-            time_lt = datetime.fromtimestamp(int(query_params['created_date.lt']))
+        if query_params.get('created_date_lt'):
+            time_lt = query_params['created_date_lt']
             queryset = model.objects.filter(created_date__lt=time_lt).order_by('-created_date')
     else:
         queryset = model.objects.order_by('-created_date').all()

--- a/beagle_etl/serializers.py
+++ b/beagle_etl/serializers.py
@@ -17,6 +17,25 @@ class JobSerializer(serializers.ModelSerializer):
             'max_retry', 'job_group')
 
 
+class JobQuerySerializer(serializers.Serializer):
+
+    status = serializers.ChoiceField([(status.name, status.value) for status in JobStatus], allow_blank=True,
+                                     required=False)
+
+    job_group = serializers.ListField(required=False)
+
+    type = serializers.ChoiceField([(k, v) for k, v in TYPES.items()], allow_blank=True,
+                                   required=False)
+
+    sample_id = serializers.CharField(required=False)
+
+    request_id = serializers.CharField(required=False)
+
+    created_date_timedelta = serializers.IntegerField(required=False)
+    created_date_gt = serializers.DateTimeField(required=False)
+    created_date_lt = serializers.DateTimeField(required=False)
+
+
 class CreateJobSerializier(serializers.ModelSerializer):
     run = serializers.ChoiceField(choices=list(TYPES.keys()), required=True)
     args = serializers.JSONField()

--- a/beagle_etl/serializers.py
+++ b/beagle_etl/serializers.py
@@ -5,6 +5,10 @@ from beagle_etl.jobs.lims_etl_jobs import TYPES
 
 
 class JobSerializer(serializers.ModelSerializer):
+    status = serializers.SerializerMethodField()
+
+    def get_status(self, obj):
+        return JobStatus(obj.status).name
 
     class Meta:
         model = Job

--- a/beagle_etl/views.py
+++ b/beagle_etl/views.py
@@ -53,7 +53,9 @@ class JobViewSet(mixins.CreateModelMixin,
             queryset = queryset.filter(args__request_id=request_id)
         st = request.query_params.get('status')
         if st:
-            queryset = queryset.filter(status=st)
+            if st not in [s.name for s in JobStatus]:
+                return Response({'details': 'Invalid status value %s: expected values %s' % (st, [s.name for s in JobStatus])}, status=status.HTTP_400_BAD_REQUEST)
+            queryset = queryset.filter(status=JobStatus[st].value)
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = JobSerializer(page, many=True)

--- a/beagle_etl/views.py
+++ b/beagle_etl/views.py
@@ -1,5 +1,4 @@
 import logging
-from notifier.models import JobGroup
 from rest_framework import mixins
 from rest_framework import status
 from beagle.pagination import time_filter
@@ -8,8 +7,9 @@ from beagle_etl.jobs.lims_etl_jobs import TYPES
 from rest_framework.generics import GenericAPIView
 from rest_framework.viewsets import GenericViewSet
 from beagle_etl.models import JobStatus, Job
+from drf_yasg.utils import swagger_auto_schema
 from .jobs.lims_etl_jobs import get_or_create_request_job
-from .serializers import JobSerializer, CreateJobSerializier, RequestIdLimsPullSerializer
+from .serializers import JobSerializer, CreateJobSerializier, RequestIdLimsPullSerializer, JobQuerySerializer
 
 
 class JobViewSet(mixins.CreateModelMixin,
@@ -35,31 +35,46 @@ class JobViewSet(mixins.CreateModelMixin,
             return Response(response.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    @swagger_auto_schema(query_serializer=JobQuerySerializer)
     def list(self, request, *args, **kwargs):
-        queryset = time_filter(Job, request.query_params)
-        job_group = request.query_params.getlist('job_group')
-        if job_group:
-            queryset = queryset.filter(job_group__in=job_group).all()
-        job_type = request.query_params.get('type')
-        if job_type:
-            if not TYPES.get(job_type):
-                return Response({'details': 'Invalid job type: %s' % job_type}, status=status.HTTP_400_BAD_REQUEST)
-            queryset = queryset.filter(run=TYPES[job_type])
-        sample_id = request.query_params.get('sample_id')
-        if sample_id:
-            queryset = queryset.filter(args__sample_id=sample_id)
-        request_id = request.query_params.get('request_id')
-        if request_id:
-            queryset = queryset.filter(args__request_id=request_id)
-        st = request.query_params.get('status')
-        if st:
-            if st not in [s.name for s in JobStatus]:
-                return Response({'details': 'Invalid status value %s: expected values %s' % (st, [s.name for s in JobStatus])}, status=status.HTTP_400_BAD_REQUEST)
-            queryset = queryset.filter(status=JobStatus[st].value)
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = JobSerializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
+        query_list_types = ['job_group', 'type', 'sample_id', 'request_id', 'created_date_timedelta', 'created_date_gt', 'created_date_lt']
+        fixed_query_params = self.fix_query_list(request.query_params, query_list_types)
+        serializer = JobQuerySerializer(data=fixed_query_params)
+        if serializer.is_valid():
+            queryset = time_filter(Job, request.query_params)
+            job_group = fixed_query_params.get('job_group')
+            if job_group:
+                queryset = queryset.filter(job_group__in=job_group).all()
+            job_type = fixed_query_params.get('type')
+            if job_type:
+                queryset = queryset.filter(run=TYPES[job_type])
+            sample_id = fixed_query_params.get('sample_id')
+            if sample_id:
+                queryset = queryset.filter(args__sample_id=sample_id)
+            request_id = fixed_query_params.get('request_id')
+            if request_id:
+                queryset = queryset.filter(args__request_id=request_id)
+            st = fixed_query_params.get('status')
+            if st:
+                queryset = queryset.filter(status=JobStatus[st].value)
+            page = self.paginate_queryset(queryset)
+            if page is not None:
+                serializer = JobSerializer(page, many=True)
+                return self.get_paginated_response(serializer.data)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def fix_query_list(self, request_query, key_list):
+        query_dict = request_query.dict()
+        for single_param in key_list:
+            query_value = request_query.get(single_param)
+            if query_value:
+                if ',' in query_value[0]:
+                    query_value = query_dict.get(single_param)
+                    query_dict[single_param] = query_value.split(",")
+                else:
+                    query_dict[single_param] = query_value
+        return query_dict
 
 
 class RequestIdLimsPullViewSet(GenericAPIView):


### PR DESCRIPTION
## Changelog:

- Status query param expects status string instead of number
- ETLJobSerializer returns status name instead of value

@nikhil is there a way I can specify query params to swagger?