### PR TITLE
Redelivery Fix/Improvements

### DIFF
--- a/beagle/settings.py
+++ b/beagle/settings.py
@@ -329,6 +329,8 @@ for n in NOTIFIERS:
 
 NOTIFIER_CC = os.environ.get("BEAGLE_NOTIFIER_CC", '') # Put "CC [~webbera] and [~socci]" for production
 
+REDELIVERY_CC = os.environ.get("BEAGLE_REDELIVERY_CC", '') # Put "CC [~songt]" for production
+
 JIRA_URL = os.environ.get("JIRA_URL", "")
 JIRA_USERNAME = os.environ.get("JIRA_USERNAME", "")
 JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "")

--- a/beagle/settings.py
+++ b/beagle/settings.py
@@ -329,8 +329,6 @@ for n in NOTIFIERS:
 
 NOTIFIER_CC = os.environ.get("BEAGLE_NOTIFIER_CC", '') # Put "CC [~webbera] and [~socci]" for production
 
-REDELIVERY_CC = os.environ.get("BEAGLE_REDELIVERY_CC", '') # Put "CC [~songt]" for production
-
 JIRA_URL = os.environ.get("JIRA_URL", "")
 JIRA_USERNAME = os.environ.get("JIRA_USERNAME", "")
 JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "")

--- a/beagle_etl/jobs/lims_etl_jobs.py
+++ b/beagle_etl/jobs/lims_etl_jobs.py
@@ -45,8 +45,7 @@ def create_request_job(request_id):
     count = Job.objects.filter(run=TYPES['REQUEST'], args__request_id=request_id,
                                status__in=[JobStatus.CREATED, JobStatus.IN_PROGRESS,
                                            JobStatus.WAITING_FOR_CHILDREN]).count()
-    redelivery = Job.objects.filter(run=TYPES['REQUEST'], args__request_id=request_id,
-                                    status=JobStatus.COMPLETED).count() > 0
+    redelivery = Job.objects.filter(run=TYPES['REQUEST'], args__request_id=request_id).count() > 0
     if count == 0:
         job_group = JobGroup()
         job_group.save()

--- a/beagle_etl/jobs/lims_etl_jobs.py
+++ b/beagle_etl/jobs/lims_etl_jobs.py
@@ -1,11 +1,13 @@
 import os
 import copy
 import logging
+from deepdiff import DeepDiff
 from django.conf import settings
 from beagle_etl.jobs import TYPES
 from notifier.models import JobGroup
 from notifier.events import ETLSetRecipeEvent, OperatorRequestEvent, SetCIReviewEvent, SetLabelEvent, \
-    NotForCIReviewEvent, UnknownAssayEvent, DisabledAssayEvent, AdminHoldEvent, CustomCaptureCCEvent, RedeliveryEvent
+    NotForCIReviewEvent, UnknownAssayEvent, DisabledAssayEvent, AdminHoldEvent, CustomCaptureCCEvent, RedeliveryEvent, \
+    RedeliveryUpdateEvent, UploadAttachmentEvent
 from notifier.tasks import send_notification, notifier_start
 from beagle_etl.models import JobStatus, Job, Operator, Assay
 from file_system.serializers import UpdateFileSerializer
@@ -18,6 +20,8 @@ from runner.tasks import create_jobs_from_request
 from file_system.helper.checksum import sha1, FailedToCalculateChecksum
 from runner.operator.helper import format_sample_name
 from beagle_etl.lims_client import LIMSClient
+import traceback
+
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +64,7 @@ def create_request_job(request_id):
                   job_group=job_group)
         job.save()
         if redelivery:
-            redelivery_event = RedeliveryEvent(str(job_group.id), request_id).to_dict()
+            redelivery_event = RedeliveryEvent(str(job_group.id)).to_dict()
             send_notification.delay(redelivery_event)
         return job
 
@@ -197,7 +201,7 @@ def get_or_create_pooled_normal_job(filepath, job_group=None):
 def create_sample_job(sample_id, igocomplete, request_id, request_metadata, redelivery=False, job_group=None):
     job = Job(run=TYPES['SAMPLE'],
               args={'sample_id': sample_id, 'igocomplete': igocomplete, 'request_id': request_id,
-                    'request_metadata': request_metadata, 'redelivery': redelivery},
+                    'request_metadata': request_metadata, 'redelivery': redelivery, 'job_group': str(job_group.id)},
               status=JobStatus.CREATED,
               max_retry=1, children=[],
               job_group=job_group)
@@ -298,7 +302,7 @@ def create_pooled_normal(filepath, file_group_id):
         logger.info("File already exist %s." % (filepath))
 
 
-def fetch_sample_metadata(sample_id, igocomplete, request_id, request_metadata, redelivery=False):
+def fetch_sample_metadata(sample_id, igocomplete, request_id, request_metadata, redelivery=False, job_group=None):
     logger.info("Fetch sample metadata for sampleId:%s" % sample_id)
     sampleMetadata = LIMSClient.get_sample_manifest(sample_id)
     try:
@@ -312,7 +316,7 @@ def fetch_sample_metadata(sample_id, igocomplete, request_id, request_metadata, 
         raise FailedToFetchSampleException(
             "Failed to fetch SampleManifest for sampleId:%s. LIMS returned %s " % (sample_id, data['igoId']))
 
-    validate_sample(sample_id, data.get('libraries'), igocomplete, redelivery)
+    validate_sample(sample_id, data.get('libraries', []), igocomplete, redelivery)
 
     libraries = data.pop('libraries')
     for library in libraries:
@@ -327,7 +331,7 @@ def fetch_sample_metadata(sample_id, igocomplete, request_id, request_metadata, 
                 logger.info("Adding file %s" % fastq)
                 create_or_update_file(fastq, request_id, settings.IMPORT_FILE_GROUP, 'fastq', igocomplete, data,
                                       library, run,
-                                      request_metadata, R1_or_R2(fastq), redelivery)
+                                      request_metadata, R1_or_R2(fastq), update=redelivery, job_group=job_group)
 
 
 def validate_sample(sample_id, libraries, igocomplete, redelivery=False):
@@ -358,7 +362,8 @@ def validate_sample(sample_id, libraries, igocomplete, redelivery=False):
             if not fastqs:
                 logger.error("Failed to fetch SampleManifest for sampleId:%s. Fastqs empty" % sample_id)
                 missing_fastq = True
-                failed_runs.append(run['runId'])
+                run_id = run['runId'] if run['runId'] else 'None'
+                failed_runs.append(run_id)
             else:
                 if not redelivery:
                     for fastq in fastqs:
@@ -431,7 +436,8 @@ def convert_to_dict(runs):
     return run_dict
 
 
-def create_or_update_file(path, request_id, file_group_id, file_type, igocomplete, data, library, run, request_metadata, r, update=False):
+def create_or_update_file(path, request_id, file_group_id, file_type, igocomplete, data, library, run, request_metadata,
+                          r, update=False, job_group=None):
     logger.info("Creating file %s " % path)
     try:
         file_group_obj = FileGroup.objects.get(id=file_group_id)
@@ -474,13 +480,29 @@ def create_or_update_file(path, request_id, file_group_id, file_type, igocomplet
         logger.error("Failed to create file %s. Error %s" % (path, str(e)))
         raise FailedToFetchSampleException("Failed to create file %s. Error %s" % (path, str(e)))
     else:
-        try:
-            f = File.objects.get(path=path)
-        except File.DoesNotExist:
+        f = FileRepository.filter(path=path).first()
+        if not f:
             create_file_object(path, file_group_obj, metadata, file_type_obj)
+            if update:
+                message = "File registered: %s" % path
+                update = RedeliveryUpdateEvent(job_group, message).to_dict()
+                send_notification.delay(update)
         else:
             if update:
-                update_file_object(f, path, metadata)
+                before = f.file.filemetadata_set.order_by('-created_date').count()
+                update_file_object(f.file, path, metadata)
+                after = f.file.filemetadata_set.order_by('-created_date').count()
+                if after != before:
+                    all_metadata = f.file.filemetadata_set.order_by('-created_date')
+                    ddiff = DeepDiff(all_metadata[1].metadata,
+                                     all_metadata[0].metadata,
+                                     ignore_order=True)
+                    diff_file_name = "%s_metadata_update.json" % f.file.file_name
+                    message = "Updating file metadata: %s, details in file %s\n" % (path, diff_file_name)
+                    update = RedeliveryUpdateEvent(job_group, message).to_dict()
+                    diff_details_event = UploadAttachmentEvent(job_group, diff_file_name, str(ddiff)).to_dict()
+                    send_notification.delay(update)
+                    send_notification.delay(diff_details_event)
             else:
                 raise FailedToFetchSampleException("File %s already exist with id %s" % (path, str(f.id)))
 

--- a/beagle_etl/tasks.py
+++ b/beagle_etl/tasks.py
@@ -81,7 +81,9 @@ class JobObject(object):
                 self._process()
                 self.job.status = JobStatus.WAITING_FOR_CHILDREN
             except Exception as e:
+                print(e)
                 if isinstance(e, ETLExceptions):
+                    print("Is this correct exception")
                     message = {"message": str(e), "code": e.code}
                 else:
                     message = {'message': str(e)}

--- a/file_system/repository/file_repository.py
+++ b/file_system/repository/file_repository.py
@@ -1,6 +1,7 @@
 from file_system.models import FileMetadata, File
 from file_system.exceptions import FileNotFoundException, InvalidQueryException
 
+
 class FileRepository(object):
 
     @classmethod
@@ -13,7 +14,7 @@ class FileRepository(object):
     @classmethod
     def distinct_files(cls, queryset):
         file_ids = queryset.values_list('file_id',flat=True)
-        metadata_ids = FileMetadata.objects.filter(file_id__in=file_ids).order_by('file', '-version').distinct('file_id').values_list('id',flat=True)
+        metadata_ids = FileMetadata.objects.filter(file_id__in=file_ids).order_by('file', '-version').distinct('file_id').values_list('id', flat=True)
         queryset = queryset.filter(id__in=metadata_ids).order_by('created_date').all()
         return queryset
 

--- a/file_system/serializers.py
+++ b/file_system/serializers.py
@@ -243,28 +243,10 @@ class UpdateFileSerializer(serializers.Serializer):
         instance.size = validated_data.get('size', instance.size)
         instance.file_group_id = validated_data.get('file_group_id', instance.file_group_id)
         instance.file_type = validated_data.get('file_type', instance.file_type)
-        ddiff = DeepDiff(validated_data.get('metadata'), instance.filemetadata_set.first().metadata, ignore_order=True)
+        ddiff = DeepDiff(validated_data.get('metadata'),
+                         instance.filemetadata_set.order_by('-created_date').first().metadata, ignore_order=True)
         if ddiff:
             metadata = FileMetadata(file=instance, metadata=validated_data.get('metadata'), user=user)
             metadata.save()
         instance.save()
         return instance
-
-
-# class BatchCreateFileSerializer(serializers.Serializer):
-#     files = serializers.ListField(required=True, allow_empty=False)
-#     metadata = serializers.JSONField(allow_null=True, default=dict)
-#     file_group = serializers.UUIDField(required=True)
-#
-#     def create(self, validated_data):
-#         request = self.context.get("request")
-#         user = request.user if request and hasattr(request, "user") else None
-#         sample = Sample(name=validated_data['name'])
-#         sample.save()
-#         metadata = SampleMetadata(sample=sample, metadata=validated_data['metadata'], user=user)
-#         metadata.save()
-#         file_group = FileGroup.objects.get(id=validated_data['file_group'])
-#         for file in validated_data['files']:
-#             File(file_name=os.path.basename(file), path=file, file_group=file_group, sample=sample).save()
-#         return sample
-

--- a/notifier/event_handler/jira_event_handler/jira_event_handler.py
+++ b/notifier/event_handler/jira_event_handler/jira_event_handler.py
@@ -57,9 +57,8 @@ class JiraEventHandler(EventHandler):
     def process_custom_capture_cc_event(self, event):
         self._add_comment_event(event)
 
-    def _add_comment_event(self, event):
-        job_group = JobGroup.objects.get(id=event.job_group)
-        self.client.comment(job_group.jira_id, str(event))
+    def process_redelivery_event(self, event):
+        self._add_comment_event(event)
 
     def process_set_label_event(self, event):
         job_group = JobGroup.objects.get(id=event.job_group)
@@ -82,3 +81,7 @@ class JiraEventHandler(EventHandler):
     def process_upload_attachment_event(self, event):
         job_group = JobGroup.objects.get(id=event.job_group)
         self.client.add_attachment(job_group.jira_id, event.file_name, event.get_content(), download=event.download)
+
+    def _add_comment_event(self, event):
+        job_group = JobGroup.objects.get(id=event.job_group)
+        self.client.comment(job_group.jira_id, str(event))

--- a/notifier/event_handler/jira_event_handler/jira_event_handler.py
+++ b/notifier/event_handler/jira_event_handler/jira_event_handler.py
@@ -22,7 +22,6 @@ class JiraEventHandler(EventHandler):
 
     def process_import_event(self, event):
         job_group = JobGroup.objects.get(id=event.job_group)
-        # self.client.update_ticket_summary(job_group.jira_id, event.request_id)
         self.client.update_ticket_description(job_group.jira_id, str(event))
 
     def process_operator_start_event(self, event):
@@ -58,16 +57,13 @@ class JiraEventHandler(EventHandler):
         self._add_comment_event(event)
 
     def process_redelivery_event(self, event):
+        self._set_label(event)
+
+    def process_redelivery_update_event(self, event):
         self._add_comment_event(event)
 
     def process_set_label_event(self, event):
-        job_group = JobGroup.objects.get(id=event.job_group)
-        ticket = self.client.get_ticket(job_group.jira_id)
-        if ticket.status_code != 200:
-            return
-        labels = ticket.json()['fields'].get('labels', [])
-        labels.append(str(event))
-        self.client.update_labels(job_group.jira_id, labels)
+        self._set_label(event)
 
     def process_transition_event(self, event):
         job_group = JobGroup.objects.get(id=event.job_group)
@@ -75,8 +71,16 @@ class JiraEventHandler(EventHandler):
         for transition in response.json().get('transitions', []):
             if transition.get('name') == str(event):
                 self.client.update_status(job_group.jira_id, transition['id'])
+                self._check_transition(job_group.jira_id, str(event), event)
                 self.logger.debug("Transition to state %s", transition.get('name'))
                 break
+
+    def _check_transition(self, jira_id, expected_status, event):
+        response = self.client.get_ticket(jira_id)
+        status = response.json()['fields']['status']['name']
+        if status == expected_status:
+            return
+        self.process_transition_event(event)
 
     def process_upload_attachment_event(self, event):
         job_group = JobGroup.objects.get(id=event.job_group)
@@ -85,3 +89,12 @@ class JiraEventHandler(EventHandler):
     def _add_comment_event(self, event):
         job_group = JobGroup.objects.get(id=event.job_group)
         self.client.comment(job_group.jira_id, str(event))
+
+    def _set_label(self, event):
+        job_group = JobGroup.objects.get(id=event.job_group)
+        ticket = self.client.get_ticket(job_group.jira_id)
+        if ticket.status_code != 200:
+            return
+        labels = ticket.json()['fields'].get('labels', [])
+        labels.append(str(event))
+        self.client.update_labels(job_group.jira_id, labels)

--- a/notifier/event_handler/noop_event_handler/noop_event_handler.py
+++ b/notifier/event_handler/noop_event_handler/noop_event_handler.py
@@ -25,29 +25,35 @@ class NoOpEventHandler(EventHandler):
     def process_etl_set_recipe_event(self, event):
         pass
 
+    def process_operator_run_event(self, event):
+        pass
+
+    def process_run_completed(self, event):
+        pass
+
     def process_operator_request_event(self, event):
         pass
 
     def process_etl_job_failed_event(self, event):
         pass
 
-    def process_operator_run_event(self, event):
+    def process_operator_error_event(self, event):
+        pass
+
+    def process_assay_event(self, event):
+        pass
+
+    def process_custom_capture_cc_event(self, event):
+        pass
+
+    def process_redelivery_event(self, event):
         pass
 
     def process_set_label_event(self, event):
-        pass
-
-    def process_run_completed(self, event):
-        pass
-
-    def process_operator_error_event(self, event):
         pass
 
     def process_transition_event(self, event):
         pass
 
     def process_upload_attachment_event(self, event):
-        pass
-
-    def process_assay_event(self, event):
         pass

--- a/notifier/event_handler/noop_event_handler/noop_event_handler.py
+++ b/notifier/event_handler/noop_event_handler/noop_event_handler.py
@@ -49,6 +49,9 @@ class NoOpEventHandler(EventHandler):
     def process_redelivery_event(self, event):
         pass
 
+    def process_redelivery_update_event(self, event):
+        pass
+
     def process_set_label_event(self, event):
         pass
 

--- a/notifier/events/__init__.py
+++ b/notifier/events/__init__.py
@@ -18,3 +18,4 @@ from .operator_start_event import OperatorStartEvent
 from .custom_capture_cc_event import CustomCaptureCCEvent
 from .cant_do_event import CantDoEvent
 from .redelivery_event import RedeliveryEvent
+from .redelivery_update_event import RedeliveryUpdateEvent

--- a/notifier/events/__init__.py
+++ b/notifier/events/__init__.py
@@ -17,3 +17,4 @@ from .custom_capture_event import AdminHoldEvent
 from .operator_start_event import OperatorStartEvent
 from .custom_capture_cc_event import CustomCaptureCCEvent
 from .cant_do_event import CantDoEvent
+from .redelivery_event import RedeliveryEvent

--- a/notifier/events/redelivery_event.py
+++ b/notifier/events/redelivery_event.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from notifier.event_handler.event import Event
+
+
+class RedeliveryEvent(Event):
+
+    def __init__(self, job_group, request_id):
+        self.job_group = job_group
+        self.request_id = request_id
+
+    @classmethod
+    def get_type(cls):
+        return "RedeliveryEvent"
+
+    @classmethod
+    def get_method(cls):
+        return "process_redelivery_event"
+
+    def __str__(self):
+        TEMPLATE = """
+        RequestId is redelivered: {request_id}. {cc}
+        """
+        return TEMPLATE.format(request_id=self.request_id, cc=settings.REDELIVERY_CC)

--- a/notifier/events/redelivery_event.py
+++ b/notifier/events/redelivery_event.py
@@ -1,12 +1,10 @@
-from django.conf import settings
 from notifier.event_handler.event import Event
 
 
 class RedeliveryEvent(Event):
 
-    def __init__(self, job_group, request_id):
+    def __init__(self, job_group):
         self.job_group = job_group
-        self.request_id = request_id
 
     @classmethod
     def get_type(cls):
@@ -17,7 +15,4 @@ class RedeliveryEvent(Event):
         return "process_redelivery_event"
 
     def __str__(self):
-        TEMPLATE = """
-        RequestId is redelivered: {request_id}. {cc}
-        """
-        return TEMPLATE.format(request_id=self.request_id, cc=settings.REDELIVERY_CC)
+        return "redelivery"

--- a/notifier/events/redelivery_update_event.py
+++ b/notifier/events/redelivery_update_event.py
@@ -1,0 +1,19 @@
+from notifier.event_handler.event import Event
+
+
+class RedeliveryUpdateEvent(Event):
+
+    def __init__(self, job_group, update):
+        self.job_group = job_group
+        self.update = update
+
+    @classmethod
+    def get_type(cls):
+        return "RedeliveryUpdateEvent"
+
+    @classmethod
+    def get_method(cls):
+        return "process_redelivery_update_event"
+
+    def __str__(self):
+        return self.update


### PR DESCRIPTION
## Changelog

Issue #387 

1. Fix logic for redelivery (if there is any ETL Job with that request_id it is a redelivery, status doesn't matter)
2. Add JIRA comment to notify CAS about redelivery