### PR TITLE
Fix retry for transition and put operator_id for run_completed

### DIFF
--- a/notifier/events/run_finished_event.py
+++ b/notifier/events/run_finished_event.py
@@ -51,7 +51,7 @@ class RunFinishedEvent(Event):
         """
         link = "%s%s%s\n" % (settings.BEAGLE_URL, '/v0/run/api/', self.run_id)
         if self.operator_run_id:
-            status = "OperatorRun {operator_run} status"
+            status = "OperatorRun {operator_run} status".format(operator_run=self.operator_run_id)
         else:
             status = "Run status"
         tags = ""


### PR DESCRIPTION
## Changelog

- Workaround for retry for changing state of the ticket to avoid Jira bug
- Fix operator_id on run_finished_event