### PR TITLE
Update copy outputs and argos qc operators to write to correct Argos pipeline version dir

### DIFF
--- a/runner/operator/argos_qc_operator/v1_1_0/argos_qc_operator.py
+++ b/runner/operator/argos_qc_operator/v1_1_0/argos_qc_operator.py
@@ -50,7 +50,13 @@ class ArgosQcOperator(Operator):
         """
         If project_prefix and job_group_id, write output to a directory
         that uses both
+
+        Also use argos version number for output instead of pipeline version
+        that's listed in Beagle
         """
+        argos_run = Run.objects.get(id=run_ids[0])
+        argos_pipeline = argos_run.app
+
         output_directory = None
         if self.output_directory_prefix:
             project_prefix = self.output_directory_prefix
@@ -64,7 +70,7 @@ class ArgosQcOperator(Operator):
                 output_directory = os.path.join(pipeline.output_directory,
                                                 "argos",
                                                 output_prefix,
-                                                pipeline_version,
+                                                argos_pipeline.version,
                                                 jg_created_date)
             argos_qc_outputs_job_data['output_directory'] = output_directory
 

--- a/runner/operator/copy_outputs_operator/v1_1_0/copy_outputs_operator.py
+++ b/runner/operator/copy_outputs_operator/v1_1_0/copy_outputs_operator.py
@@ -65,7 +65,14 @@ class CopyOutputsOperator(Operator):
         """
         If project_prefix and job_group_id, write output to a directory
         that uses both
+
+        Also use argos version number for output instead of pipeline version
+        that's listed in Beagle
         """
+
+        argos_run = Run.objects.get(id=run_ids[0])
+        argos_pipeline = argos_run.app
+
         output_directory = None
         if project_prefix:
             tags["project_prefix"] = project_prefix
@@ -76,7 +83,7 @@ class CopyOutputsOperator(Operator):
                 output_directory = os.path.join(pipeline.output_directory,
                                                 "argos",
                                                 output_prefix,
-                                                pipeline_version,
+                                                argos_pipeline.version,
                                                 jg_created_date)
             copy_outputs_job_data['output_directory'] = output_directory
         copy_outputs_job = [(APIRunCreateSerializer(


### PR DESCRIPTION
Updated operators, now will output to dir defined by version of argos…pipeline