### PR TITLE
add pairing support for impact505 dmp normal

### DIFF
--- a/runner/operator/argos_operator/v1_1_0/bin/retrieve_samples_by_query.py
+++ b/runner/operator/argos_operator/v1_1_0/bin/retrieve_samples_by_query.py
@@ -253,6 +253,8 @@ def build_dmp_query(patient_id, bait_set):
         value = "IMPACT468"
     if "hemepact_v4" in bait_set.lower():
         value = "HEMEPACT"
+    if "impact505" in bait_set.lower():
+        value = "IMPACT505"
     assay = Q(metadata__cmo_assay=value)
     patient = Q(metadata__patient__cmo=patient_id.lstrip('C-'))
     normal = Q(metadata__type='N')


### PR DESCRIPTION
IGO told me they are expecting a request where the investigators expect IMPACT505 dmp normals to be paired with the tumor samples.
I think this is the only place that needs to be modified in beagle so far.. 