### PR TITLE
Speed up admin Run page + add ability to export files as JSON

### DIFF
--- a/beagle/settings.py
+++ b/beagle/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_extensions',
+    'import_export',
     'rest_framework',
     'corsheaders',
     'drf_multiple_model',

--- a/file_system/admin.py
+++ b/file_system/admin.py
@@ -1,10 +1,11 @@
 from django.contrib import admin
+from import_export.admin import ExportActionMixin
 from .models import Storage, File, FileType, FileMetadata, FileGroup, FileGroupMetadata, FileRunMap, ImportMetadata, Sample
 
 # Register your models here.
 
 
-class FileAdmin(admin.ModelAdmin):
+class FileAdmin(ExportActionMixin, admin.ModelAdmin):
     list_display = ('id', 'file_name', 'file_group', 'size')
     search_fields = ['file_name']
 
@@ -18,13 +19,13 @@ class FileRunMapAdmin(admin.ModelAdmin):
     list_display = ('file', 'run')
 
 
-class FileMetadataAdmin(admin.ModelAdmin):
+class FileMetadataAdmin(ExportActionMixin, admin.ModelAdmin):
     list_display = ('file', 'version', 'metadata')
     autocomplete_fields = ['file']
     search_fields = ('id', 'metadata__requestId')
 
 
-class ImportMetadataAdmin(admin.ModelAdmin):
+class ImportMetadataAdmin(ExportActionMixin, admin.ModelAdmin):
     list_display = ('file',)
     search_fields = ('file__id',)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ psycopg2-binary
 django-extensions==2.2.9
 gunicorn==20.0.4
 dj-static==0.0.6
+django-import-export==2.4.0

--- a/runner/admin.py
+++ b/runner/admin.py
@@ -16,6 +16,7 @@ class PipelineAdmin(admin.ModelAdmin):
 class RunAdmin(admin.ModelAdmin):
     list_display = ('id', 'name', link_relation("app"), link_relation("operator_run"), 'tags', 'status', 'execution_id', 'created_date', 'notify_for_outputs')
     ordering = ('-created_date',)
+    readonly_fields = ('samples', 'job_group', 'job_group_notifier', 'operator_run', 'app')
 
 
 class OperatorRunAdmin(admin.ModelAdmin):


### PR DESCRIPTION
Run page takes a while to load for me when I'm looking for results, this will speed it up.

It also adds the ability to export Files as JSON/CSV to more easily generate fixtures.

Make sure to install requirements when deploying.

<img width="679" alt="Screen Shot 2020-12-10 at 15 16 22" src="https://user-images.githubusercontent.com/17934/101824778-acc8ae00-3afa-11eb-80e2-5f79b736da00.png">
