### PR TITLE
fix access downstream operators

### DIFF
--- a/fixtures/tests/access_snv/files.json
+++ b/fixtures/tests/access_snv/files.json
@@ -32,7 +32,7 @@
             "created_date": "2020-01-06T19:59:50.576Z",
             "modified_date": "2020-01-06T19:59:50.579Z",
             "file_name": "C-000884-L011-d_cl_aln_srt_MD_IR_FX_BR.bam",
-            "path": "/juno/work/access/production/runs/Project_06302_AD/bam_qc/TDM/06302_AD_group_3-1.2.9/C-000884-L011-d/C-000884-L011-d_cl_aln_srt_MD_IR_FX_BR.bam",
+            "path": "/juno/work/access/production/runs/Project_06302_AD/small_variants/linked_bams/linked_simplex_bams/C-000884-L011-d_cl_aln_srt_MD_IR_FX_BR.bam",
             "file_type": 3,
             "size": 0,
             "file_group": "1a1b29cf-3bc2-4f6c-b376-d4c5d701166a"

--- a/fixtures/tests/access_snv/files.json
+++ b/fixtures/tests/access_snv/files.json
@@ -32,7 +32,7 @@
             "created_date": "2020-01-06T19:59:50.576Z",
             "modified_date": "2020-01-06T19:59:50.579Z",
             "file_name": "C-000884-L011-d_cl_aln_srt_MD_IR_FX_BR.bam",
-            "path": "/juno/work/access/production/runs/Project_06302_AD/small_variants/linked_bams/linked_simplex_bams/C-000884-L011-d_cl_aln_srt_MD_IR_FX_BR.bam",
+            "path": "/juno/work/access/production/runs/Project_06302_AD/bam_qc/TDM/06302_AD_group_3-1.2.9/C-000884-L011-d/C-000884-L011-d_cl_aln_srt_MD_IR_FX_BR.bam",
             "file_type": 3,
             "size": 0,
             "file_group": "1a1b29cf-3bc2-4f6c-b376-d4c5d701166a"

--- a/fixtures/tests/access_snv/files_metadata.json
+++ b/fixtures/tests/access_snv/files_metadata.json
@@ -8,28 +8,7 @@
             "modified_date": "2020-01-06T19:59:50.583Z",
             "file": "fffff52a-0696-48d4-9ca5-6580daa44ab3",
             "version": 0,
-            "metadata": {
-                "sampleId": "06302_AB_1",
-                "patientId": "C-000884",
-                "requestId": "06302_AB",
-                "sampleName": "C-000884-L011-d",
-                "recipe": "-",
-                "dataAnalystName": "-",
-                "dataAnalystEmail": "-",
-                "investigatorName": "-",
-                "investigatorEmail": "-",
-                "labHeadName": "-",
-                "labHeadEmail": "-",
-                "piEmail": "-",
-                "projectManagerName": "-",
-                "qcAccessEmails": "-",
-                "flowCellLanes": [
-                    3,
-                    4
-                ],
-                "tumorOrNormal": "Tumor",
-                "igocomplete": true
-            },
+            "metadata": {},
             "user": null
         }
     },
@@ -42,61 +21,19 @@
             "modified_date": "2020-01-06T19:59:50.596Z",
             "file": "2f77f3ac-ab25-4a02-90bd-86542401ac81",
             "version": 0,
-            "metadata": {
-                "sampleId": "06302_AB_1",
-                "patientId": "C-000884",
-                "sampleName": "C-000884-L011-d",
-                "requestId": "06302_AB",
-                "recipe": "-",
-                "dataAnalystName": "-",
-                "dataAnalystEmail": "-",
-                "investigatorName": "-",
-                "investigatorEmail": "-",
-                "labHeadName": "-",
-                "labHeadEmail": "-",
-                "piEmail": "-",
-                "projectManagerName": "-",
-                "qcAccessEmails": "-",
-                "flowCellLanes": [
-                    3,
-                    4
-                ],
-                "tumorOrNormal": "Tumor",
-                "igocomplete": true
-            },
+            "metadata": {},
             "user": null
         }
     },{
         "model": "file_system.filemetadata",
-        "pk": "fffff52a-0696-48d4-9ca5-6580daa44aaa",
+        "pk": "fffff52a-0696-48d4-9ca5-6580daa44adf",
         "fields": {
             "latest": true,
             "created_date": "2020-01-06T19:59:50.583Z",
             "modified_date": "2020-01-06T19:59:50.583Z",
             "file": "fffff52a-0696-48d4-9ca5-6580daa44aaa",
             "version": 0,
-            "metadata": {
-                "sampleId": "06302_AB_1",
-                "patientId": "C-000884",
-                "requestId": "06302_AB",
-                "sampleName": "C-000884-L011-d",
-                "recipe": "-",
-                "dataAnalystName": "-",
-                "dataAnalystEmail": "-",
-                "investigatorName": "-",
-                "investigatorEmail": "-",
-                "labHeadName": "-",
-                "labHeadEmail": "-",
-                "piEmail": "-",
-                "projectManagerName": "-",
-                "qcAccessEmails": "-",
-                "flowCellLanes": [
-                    3,
-                    4
-                ],
-                "tumorOrNormal": "Tumor",
-                "igocomplete": true
-            },
+            "metadata": {},
             "user": null
         }
     },
@@ -109,28 +46,7 @@
             "modified_date": "2020-01-06T19:59:50.596Z",
             "file": "2f77f3ac-ab25-4a02-90bd-86542401acbb",
             "version": 0,
-            "metadata": {
-                "sampleId": "06302_AB_1",
-                "patientId": "C-000884",
-                "sampleName": "C-000884-L011-d",
-                "requestId": "06302_AB",
-                "recipe": "-",
-                "dataAnalystName": "-",
-                "dataAnalystEmail": "-",
-                "investigatorName": "-",
-                "investigatorEmail": "-",
-                "labHeadName": "-",
-                "labHeadEmail": "-",
-                "piEmail": "-",
-                "projectManagerName": "-",
-                "qcAccessEmails": "-",
-                "flowCellLanes": [
-                    3,
-                    4
-                ],
-                "tumorOrNormal": "Tumor",
-                "igocomplete": true
-            },
+            "metadata": {},
             "user": null
         }
     },{
@@ -142,28 +58,7 @@
             "modified_date": "2020-01-06T19:59:50.583Z",
             "file": "2f77f3ac-ab25-4a02-90bd-86542401ac80",
             "version": 0,
-            "metadata": {
-                "sampleId": "06302_AB_2",
-                "patientId": "C-000884",
-                "requestId": "06302_AB",
-                "sampleName": "C-000884-N004-d",
-                "recipe": "-",
-                "dataAnalystName": "-",
-                "dataAnalystEmail": "-",
-                "investigatorName": "-",
-                "investigatorEmail": "-",
-                "labHeadName": "-",
-                "labHeadEmail": "-",
-                "piEmail": "-",
-                "projectManagerName": "-",
-                "qcAccessEmails": "-",
-                "flowCellLanes": [
-                    3,
-                    4
-                ],
-                "tumorOrNormal": "Normal",
-                "igocomplete": true
-            },
+            "metadata": {},
             "user": null
         }
     },{
@@ -175,17 +70,7 @@
             "modified_date": "2020-01-06T19:59:50.583Z",
             "file": "2f77f3ac-ab25-4a02-90bd-86542401acda",
             "version": 0,
-            "metadata": {
-                "sampleId": "06302_AB_2",
-                "patientId": "C-000884",
-                "requestId": "06302_AB",
-                "sampleName": "C-000884-N004-d",
-                "flowCellLanes": [
-                    3,
-                    4
-                ],
-                "tumorOrNormal": "Normal"
-            },
+            "metadata": {},
             "user": null
         }
     },

--- a/runner/operator/access/v1_0_0/msi/__init__.py
+++ b/runner/operator/access/v1_0_0/msi/__init__.py
@@ -62,37 +62,27 @@ class AccessLegacyMSIOperator(Operator):
 
         for i, tumor_sample_id in enumerate(sample_ids_to_run):
             # Find the Tumor Standard bam
-            tumor_bam = FileRepository.filter(
-                file_type='bam',
-                path_regex='_cl_aln_srt_MD_IR_FX_BR.bam',
-                metadata={
-                    'tumorOrNormal': 'Tumor',
-                    'sampleName': tumor_sample_id
-                }
-            )
+            sample_regex = r'{}_cl_aln_srt_MD_IR_FX_BR.bam'.format(tumor_sample_id)
+            tumor_bam = FileRepository.filter(file_name_regex=sample_regex)
+
             if not len(tumor_bam) == 1:
                 msg = 'Found incorrect number of matching bam files ({}) for sample {}'
                 msg = msg.format(len(tumor_bam), tumor_sample_id)
                 raise Exception(msg)
+                # Todo: if > 1, choose based on run ID
 
             tumor_bam = tumor_bam[0]
-            patient_id = tumor_bam.metadata['patientId']
+            patient_id = tumor_sample_id.split('-')[0:2]
 
             # Find the matched Normal Standard bam (which could be associated with a different request_id)
-            # Todo: we need to make sure that "-N0" is an acceptable way to find normal samples
-            # Todo: use tumorOrNormal field for this once this is solved:
-            # https://cwl.discourse.group/t/expressiontool-with-record-output/239/2
-            matched_normal_bam = FileRepository.filter(
-                file_type='bam',
-                path_regex=NORMAL_SEARCH + '.*_cl_aln_srt_MD_IR_FX_BR.bam',
-                metadata={
-                    'patientId': patient_id,
-                }
-            ).latest('created_date')
+            sample_regex = r'{}.*{}.*_cl_aln_srt_MD_IR_FX_BR.bam'.format(patient_id, NORMAL_SEARCH)
+            matched_normal_bam = FileRepository.filter(path_regex=sample_regex)
 
-            if not matched_normal_bam:
-                msg = 'No matching unfiltered normals Bam found for patient {}'.format(patient_id)
+            if not len(matched_normal_bam) > 0:
+                msg = 'No matching standard normal Bam found for patient {}'.format(patient_id)
                 raise Exception(msg)
+
+            matched_normal_bam = matched_normal_bam.order_by('-created_date').first()
 
             sample_ids.append(tumor_sample_id)
             tumor_bams.append(tumor_bam)

--- a/runner/operator/access/v1_0_0/snps_and_indels/__init__.py
+++ b/runner/operator/access/v1_0_0/snps_and_indels/__init__.py
@@ -22,7 +22,7 @@ WORKDIR = os.path.dirname(os.path.abspath(__file__))
 ACCESS_CURATED_BAMS_FILE_GROUP_SLUG = 'access_curated_normals'
 ACCESS_DEFAULT_NORMAL_ID = 'DONOR22-TP'
 ACCESS_DEFAULT_NORMAL_FILENAME = 'DONOR22-TP_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX-duplex.bam'
-
+NORMAL_SAMPLE_SEARCH = '-N0'
 
 class AccessLegacySNVOperator(Operator):
 
@@ -62,58 +62,68 @@ class AccessLegacySNVOperator(Operator):
 
         for i, tumor_sample_id in enumerate(tumors_to_run):
 
-            tumor_duplex_bam = FileRepository.filter(
-                file_type='bam',
-                path_regex='__aln_srt_IR_FX-duplex.bam',
-                metadata={
-                    'tumorOrNormal': 'Tumor',
-                    'sampleName': tumor_sample_id
-                }
-            )
-            if not len(tumor_duplex_bam) == 1:
-                msg = 'Found incorrect number of matching duplex bam files ({}) for sample {}'
-                msg = msg.format(len(tumor_duplex_bam), tumor_sample_id)
+            # Locate the Duplex BAM
+            sample_regex = r'{}.*__aln_srt_IR_FX-duplex.bam'.format(tumor_sample_id)
+
+            tumor_duplex_bam = FileRepository.filter(path_regex=sample_regex)
+            if len(tumor_duplex_bam) < 1:
+                msg = 'ERROR: Could not find matching duplex bam file for sample {}'
+                msg = msg.format(tumor_sample_id)
                 logger.exception(msg)
                 raise Exception(msg)
-            tumor_duplex_bam = tumor_duplex_bam[0]
-
-            tumor_simplex_bam = FileRepository.filter(
-                file_type='bam',
-                path_regex='__aln_srt_IR_FX-simplex.bam',
-                metadata={
-                    'tumorOrNormal': 'Tumor',
-                    'sampleName': tumor_sample_id
-                }
-            )
-            if not len(tumor_simplex_bam) == 1:
-                msg = 'Found incorrect number of matching simplex bam files ({}) for sample {}'
-                msg = msg.format(len(tumor_duplex_bam), tumor_sample_id)
-                logger.exception(msg)
-                raise Exception(msg)
-            tumor_simplex_bam = tumor_simplex_bam[0]
-
-            patient_id = tumor_duplex_bam.metadata['patientId']
-            # Use the path regex suffix to get only access unfiltered bams
-            unfiltered_matched_normal_bam = FileRepository.filter(
-                file_type='bam',
-                path_regex='__aln_srt_IR_FX.bam',
-                metadata={
-                    'patientId': patient_id,
-                    'tumorOrNormal': 'Normal',
-                }
-            ).latest('created_date')
-
-            if not unfiltered_matched_normal_bam:
-                msg = 'No matching unfiltered normals Bam found for patient {}'.format(patient_id)
+            if len(tumor_duplex_bam) > 1:
+                msg = 'WARNING: Found more than one matching duplex bam file for sample {}. \
+                We will choose the most recently-created one for this run.'
+                msg = msg.format(tumor_sample_id)
                 logger.warning(msg)
-                # Skip running this sample
-                continue
+            # Take the latest one
+            tumor_duplex_bam = tumor_duplex_bam.order_by('-created_date').first()
+
+            # Locate the Simplex BAM
+            sample_regex = r'{}.*__aln_srt_IR_FX-simplex.bam'.format(tumor_sample_id)
+            tumor_simplex_bam = FileRepository.filter(path_regex=sample_regex)
+            if len(tumor_simplex_bam) < 1:
+                msg = 'ERROR: Could not find matching simplex bam file for sample {}'
+                msg = msg.format(tumor_sample_id)
+                logger.exception(msg)
+                raise Exception(msg)
+            if len(tumor_simplex_bam) > 1:
+                msg = 'WARNING: Found more than one matching simplex bam file for sample {}. ' \
+                      'We will choose the most recently-created one for this run.'
+                msg = msg.format(tumor_sample_id)
+                logger.warning(msg)
+            # Take the latest one
+            tumor_simplex_bam = tumor_simplex_bam.order_by('-created_date').first()
+
+            patient_id = tumor_sample_id.split('-')[0:2]
+
+            # Locate the Matched, Unfiltered, Normal BAM
+            sample_regex = r'{}.*{}.*__aln_srt_IR_FX.bam'.format(patient_id, NORMAL_SAMPLE_SEARCH)
+            unfiltered_matched_normal_bam = FileRepository.filter(path_regex=sample_regex)
+            if len(unfiltered_matched_normal_bam) < 1:
+                msg = 'WARNING: Could not find matching unfiltered normal bam file for sample {}' \
+                      'We will skip running this sample.'
+                msg = msg.format(tumor_sample_id)
+                logger.warning(msg)
+                raise Exception(msg)
+            if len(unfiltered_matched_normal_bam) > 1:
+                msg = 'WARNING: Found more than one matching unfiltered normal bam file for tumor sample {}. ' \
+                      'We will choose the most recently-created one for this run.'
+                msg = msg.format(tumor_sample_id)
+                logger.warning(msg)
+            # Take the latest one
+            unfiltered_matched_normal_bam = unfiltered_matched_normal_bam.order_by('-created_date').first()
+
+            # Parse the Normal Sample ID from the file name
+            # Todo: Stop using file path for this, once output_metadata is being supplied in access legacy operator
+            unfiltered_matched_normal_file_base = unfiltered_matched_normal_bam.file.path.split('/')[-1]
+            unfiltered_matched_normal_sample_id = '-'.join(unfiltered_matched_normal_file_base.split('-')[0:3])
 
             sample_ids.append(tumor_sample_id)
             tumor_duplex_bams.append(tumor_duplex_bam)
             tumor_simplex_bams.append(tumor_simplex_bam)
             matched_normals.append(unfiltered_matched_normal_bam)
-            matched_normal_ids.append(unfiltered_matched_normal_bam.metadata['sampleName'])
+            matched_normal_ids.append(unfiltered_matched_normal_sample_id)
 
         sample_inputs = []
         for i, b in enumerate(tumor_duplex_bams):

--- a/runner/tests/operator/access_msi/test_msi_operator.py
+++ b/runner/tests/operator/access_msi/test_msi_operator.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from beagle.settings import ROOT_DIR
 from beagle_etl.models import Operator
 from runner.operator.operator_factory import OperatorFactory
-from runner.operator.access.v1_0_0.structural_variants import AccessLegacySVOperator
+from runner.operator.access.v1_0_0.msi import AccessLegacyMSIOperator
 
 
 FIXTURES = [
@@ -16,8 +16,6 @@ FIXTURES = [
     "fixtures/tests/access_snv/operator_run.json",
     "fixtures/tests/access_snv/ports.json",
     "fixtures/tests/access_snv/runs.json",
-    "fixtures/tests/access_snv/sv_bams/files.json",
-    "fixtures/tests/access_snv/sv_bams/files_metadata.json",
 ]
 
 COMMON_FIXTURES = [
@@ -31,44 +29,43 @@ COMMON_FIXTURES = [
 ]
 
 
-class TestAccessSVOperator(TestCase):
+class TestAccessMSIOperator(TestCase):
 
     fixtures = [os.path.join(ROOT_DIR, f) for f in FIXTURES + COMMON_FIXTURES]
 
-    def test_access_legacy_sv_operator(self):
+    def test_access_legacy_msi_operator(self):
         """
-        Test that an Access legacy SV operator instance can be created and validated
+        Test that an Access legacy MSI operator instance can be created and validated
         """
-        # create access SV operator
+        # create access MSI operator
         request_id = "access_legacy_test_request"
 
         # todo: avoid the magic number here:
-        operator_model = Operator.objects.get(id=6)
+        operator_model = Operator.objects.get(id=7)
         operator = OperatorFactory.get_by_model(operator_model, request_id=request_id)
-        self.assertEqual(operator.get_pipeline_id(), "65419097-a2b8-4d57-a8ab-c4c4cddcbead")
-        self.assertEqual(str(operator.model), "AccessLegacySVOperator")
+        self.assertEqual(operator.get_pipeline_id(), "65419097-a2b8-4d57-a8ab-c4c4cddcbeee")
+        self.assertEqual(str(operator.model), "AccessLegacyMSIOperator")
         self.assertEqual(operator.request_id, request_id)
         self.assertEqual(operator._jobs, [])
 
-        pipeline_slug = "AccessLegacySVOperator"
-        access_legacy_sv_model = Operator.objects.get(slug=pipeline_slug)
-        operator = AccessLegacySVOperator(access_legacy_sv_model, request_id=request_id, run_ids=['bc23076e-f477-4578-943c-1fbf6f1fca42'])
+        pipeline_slug = "AccessLegacyMSIOperator"
+        access_legacy_msi_model = Operator.objects.get(slug=pipeline_slug)
+        operator = AccessLegacyMSIOperator(access_legacy_msi_model, request_id=request_id, run_ids=['bc23076e-f477-4578-943c-1fbf6f1fca42'])
 
-        self.assertTrue(isinstance(operator, AccessLegacySVOperator))
+        self.assertTrue(isinstance(operator, AccessLegacyMSIOperator))
         self.assertTrue(operator.request_id == request_id)
         self.assertTrue(operator._jobs == [])
         self.assertEqual(operator.run_ids, ['bc23076e-f477-4578-943c-1fbf6f1fca42'])
-        self.assertEqual(operator.get_pipeline_id(), "65419097-a2b8-4d57-a8ab-c4c4cddcbead")
+        self.assertEqual(operator.get_pipeline_id(), "65419097-a2b8-4d57-a8ab-c4c4cddcbeee")
 
         # Create and validate the input data
         input_data = operator.get_sample_inputs()
-
         required_input_fields = [
-            'sv_sample_id',
-            'sv_tumor_bams',
+            'tumor_bam',
+            'normal_bam',
+            'sample_name',
         ]
         for inputs in input_data:
             for field in required_input_fields:
                 self.assertIn(field, inputs)
                 self.assertEqual(len(inputs[field]), 1)
-            self.assertIn('sv_normal_bam', inputs)

--- a/runner/tests/operator/access_snps_and_indels/test_snps_and_indels_operator.py
+++ b/runner/tests/operator/access_snps_and_indels/test_snps_and_indels_operator.py
@@ -69,15 +69,22 @@ class TestAccessSNVOperator(TestCase):
 
         # Create and validate the input data
         input_data = operator.get_sample_inputs()
+
         required_input_fields = [
             'tumor_bams',
             'normal_bams',
             'tumor_sample_names',
             'normal_sample_names',
             'matched_normal_ids',
+        ]
+        required_input_fields_length_3 = [
             'genotyping_bams',
             'genotyping_bams_ids',
         ]
         for inputs in input_data:
             for field in required_input_fields:
                 self.assertIn(field, inputs)
+                self.assertEqual(len(inputs[field]), 1)
+            for field in required_input_fields_length_3:
+                self.assertIn(field, inputs)
+                self.assertEqual(len(inputs[field]), 5)


### PR DESCRIPTION
I thought that FileMetadata objects would be available to query for files that are outputs from upstream pipeline runs, but it is just the File objects that are created.

This PR makes use of the file paths to query for matching T/N duplex/simplex/standard access bams in the ACCESS SV, SNV, and MSI operators.

Also, I added a test case for the MSI operator