### PR TITLE
Ij/access bam search fix

### DIFF
--- a/fixtures/tests/access_snv/ports.json
+++ b/fixtures/tests/access_snv/ports.json
@@ -57,7 +57,7 @@
                 "location": "bid://fffff52a-0696-48d4-9ca5-6580daa44aaa"
             }],
             "value": [{
-                    "path": "/juno/work/access/production/runs/Project_06302_AD/bam_qc/TDM/06302_AD_group_3-1.2.9/C-000884-L011-d/C-000884-L011-d_cl_aln_srt_MD_IR_FX_BR.bam",
+                    "location": "/juno/work/access/production/runs/Project_06302_AD/bam_qc/TDM/06302_AD_group_3-1.2.9/C-000884-L011-d/C-000884-L011-d_cl_aln_srt_MD_IR_FX_BR.bam",
                     "size": 7313069069,
                     "class": "File"
                 }

--- a/runner/operator/access/v1_0_0/msi/__init__.py
+++ b/runner/operator/access/v1_0_0/msi/__init__.py
@@ -62,7 +62,7 @@ class AccessLegacyMSIOperator(Operator):
 
         for i, tumor_sample_id in enumerate(sample_ids_to_run):
             # Find the Tumor Standard bam
-            sample_regex = r'{}_cl_aln_srt_MD_IR_FX_BR.bam'.format(tumor_sample_id)
+            sample_regex = r'{}_cl_aln_srt_MD_IR_FX_BR.bam$'.format(tumor_sample_id)
             tumor_bam = FileRepository.filter(file_name_regex=sample_regex)
 
             if not len(tumor_bam) == 1:
@@ -75,7 +75,7 @@ class AccessLegacyMSIOperator(Operator):
             patient_id = tumor_sample_id.split('-')[0:2]
 
             # Find the matched Normal Standard bam (which could be associated with a different request_id)
-            sample_regex = r'{}.*{}.*_cl_aln_srt_MD_IR_FX_BR.bam'.format(patient_id, NORMAL_SEARCH)
+            sample_regex = r'{}.*{}.*_cl_aln_srt_MD_IR_FX_BR.bam$'.format(patient_id, NORMAL_SEARCH)
             matched_normal_bam = FileRepository.filter(path_regex=sample_regex)
 
             if not len(matched_normal_bam) > 0:

--- a/runner/operator/access/v1_0_0/msi/__init__.py
+++ b/runner/operator/access/v1_0_0/msi/__init__.py
@@ -53,8 +53,8 @@ class AccessLegacyMSIOperator(Operator):
 
         # Filter to only tumor bam files
         # Todo: Use separate metadata fields for Tumor / sample ID designation instead of file name
-        standard_tumor_bam_files = [f for p in standard_bam_ports for f in p.value if TUMOR_SEARCH in f['path'].split('/')[-1]]
-        sample_ids_to_run = [f['path'].split('/')[-1].split(SAMPLE_ID_SEP)[0] for f in standard_tumor_bam_files]
+        standard_tumor_bam_files = [f for p in standard_bam_ports for f in p.value if TUMOR_SEARCH in f['location'].split('/')[-1]]
+        sample_ids_to_run = [f['location'].split('/')[-1].split(SAMPLE_ID_SEP)[0] for f in standard_tumor_bam_files]
 
         sample_ids = []
         tumor_bams = []

--- a/runner/operator/access/v1_0_0/msi/__init__.py
+++ b/runner/operator/access/v1_0_0/msi/__init__.py
@@ -36,6 +36,7 @@ class AccessLegacyMSIOperator(Operator):
         # Get the latest completed runs for the given request ID
         group_id = Run.objects.filter(
             tags__requestId=self.request_id,
+            app__name='access legacy',
             status=RunStatus.COMPLETED
         ).order_by('-finished_date').first().job_group
 

--- a/runner/operator/access/v1_0_0/snps_and_indels/__init__.py
+++ b/runner/operator/access/v1_0_0/snps_and_indels/__init__.py
@@ -21,7 +21,7 @@ WORKDIR = os.path.dirname(os.path.abspath(__file__))
 
 ACCESS_CURATED_BAMS_FILE_GROUP_SLUG = 'access_curated_normals'
 ACCESS_DEFAULT_NORMAL_ID = 'DONOR22-TP'
-ACCESS_DEFAULT_NORMAL_FILENAME = 'DONOR22-TP_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX-duplex.bam'
+ACCESS_DEFAULT_NORMAL_FILENAME = 'DONOR22-TP_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX-duplex.bam$'
 NORMAL_SAMPLE_SEARCH = '-N0'
 
 class AccessLegacySNVOperator(Operator):
@@ -63,7 +63,7 @@ class AccessLegacySNVOperator(Operator):
         for i, tumor_sample_id in enumerate(tumors_to_run):
 
             # Locate the Duplex BAM
-            sample_regex = r'{}.*__aln_srt_IR_FX-duplex.bam'.format(tumor_sample_id)
+            sample_regex = r'{}.*__aln_srt_IR_FX-duplex.bam$'.format(tumor_sample_id)
 
             tumor_duplex_bam = FileRepository.filter(path_regex=sample_regex)
             if len(tumor_duplex_bam) < 1:
@@ -80,7 +80,7 @@ class AccessLegacySNVOperator(Operator):
             tumor_duplex_bam = tumor_duplex_bam.order_by('-created_date').first()
 
             # Locate the Simplex BAM
-            sample_regex = r'{}.*__aln_srt_IR_FX-simplex.bam'.format(tumor_sample_id)
+            sample_regex = r'{}.*__aln_srt_IR_FX-simplex.bam$'.format(tumor_sample_id)
             tumor_simplex_bam = FileRepository.filter(path_regex=sample_regex)
             if len(tumor_simplex_bam) < 1:
                 msg = 'ERROR: Could not find matching simplex bam file for sample {}'
@@ -98,7 +98,7 @@ class AccessLegacySNVOperator(Operator):
             patient_id = tumor_sample_id.split('-')[0:2]
 
             # Locate the Matched, Unfiltered, Normal BAM
-            sample_regex = r'{}.*{}.*__aln_srt_IR_FX.bam'.format(patient_id, NORMAL_SAMPLE_SEARCH)
+            sample_regex = r'{}.*{}.*__aln_srt_IR_FX.bam$'.format(patient_id, NORMAL_SAMPLE_SEARCH)
             unfiltered_matched_normal_bam = FileRepository.filter(path_regex=sample_regex)
             if len(unfiltered_matched_normal_bam) < 1:
                 msg = 'WARNING: Could not find matching unfiltered normal bam file for sample {}' \

--- a/runner/operator/access/v1_0_0/snps_and_indels/__init__.py
+++ b/runner/operator/access/v1_0_0/snps_and_indels/__init__.py
@@ -35,7 +35,6 @@ class AccessLegacySNVOperator(Operator):
         # Get the latest completed runs for the given request ID
         group_id = Run.objects.filter(
             tags__requestId=self.request_id,
-            app__name='access legacy',
             status=RunStatus.COMPLETED
         ).order_by('-finished_date').first().job_group
 

--- a/runner/operator/access/v1_0_0/snps_and_indels/__init__.py
+++ b/runner/operator/access/v1_0_0/snps_and_indels/__init__.py
@@ -35,6 +35,7 @@ class AccessLegacySNVOperator(Operator):
         # Get the latest completed runs for the given request ID
         group_id = Run.objects.filter(
             tags__requestId=self.request_id,
+            app__name='access legacy',
             status=RunStatus.COMPLETED
         ).order_by('-finished_date').first().job_group
 

--- a/runner/operator/access/v1_0_0/structural_variants/__init__.py
+++ b/runner/operator/access/v1_0_0/structural_variants/__init__.py
@@ -105,7 +105,7 @@ class AccessLegacySVOperator(Operator):
             tumor_sample_names = [tumor_sample_id]
             tumor_bams = [{
                 "class": "File",
-                "location": tumor_bam['location']
+                "location": 'juno://' + tumor_bam['location']
             }]
 
             normal_bam = FileRepository.filter(

--- a/runner/operator/access/v1_0_0/structural_variants/__init__.py
+++ b/runner/operator/access/v1_0_0/structural_variants/__init__.py
@@ -33,9 +33,10 @@ class AccessLegacySVOperator(Operator):
 
         :return: list of json_objects
         """
-        # Get the latest completed runs for the given request ID
+        # Get the latest completed bam generation run for the given request ID
         group_id = Run.objects.filter(
             tags__requestId=self.request_id,
+            app='access legacy',
             status=RunStatus.COMPLETED
         ).order_by('-finished_date').first().job_group
 

--- a/runner/operator/access/v1_0_0/structural_variants/__init__.py
+++ b/runner/operator/access/v1_0_0/structural_variants/__init__.py
@@ -15,7 +15,7 @@ WORKDIR = os.path.dirname(os.path.abspath(__file__))
 TUMOR_OR_NORMAL_SEARCH = '-L0'
 SAMPLE_ID_SEP = '_cl_aln'
 ACCESS_DEFAULT_SV_NORMAL_ID = 'DONOR22-TP'
-ACCESS_DEFAULT_SV_NORMAL_FILENAME = 'DONOR22-TP_cl_aln_srt_MD_IR_FX_BR.bam$'
+ACCESS_DEFAULT_SV_NORMAL_FILENAME = r'DONOR22-TP_cl_aln_srt_MD_IR_FX_BR.bam$'
 
 
 class AccessLegacySVOperator(Operator):

--- a/runner/operator/access/v1_0_0/structural_variants/__init__.py
+++ b/runner/operator/access/v1_0_0/structural_variants/__init__.py
@@ -105,7 +105,7 @@ class AccessLegacySVOperator(Operator):
             tumor_sample_names = [tumor_sample_id]
             tumor_bams = [{
                 "class": "File",
-                "location": 'juno://' + tumor_bam['path']
+                "location": tumor_bam['location']
             }]
 
             normal_bam = FileRepository.filter(

--- a/runner/operator/access/v1_0_0/structural_variants/__init__.py
+++ b/runner/operator/access/v1_0_0/structural_variants/__init__.py
@@ -15,7 +15,7 @@ WORKDIR = os.path.dirname(os.path.abspath(__file__))
 TUMOR_OR_NORMAL_SEARCH = '-L0'
 SAMPLE_ID_SEP = '_cl_aln'
 ACCESS_DEFAULT_SV_NORMAL_ID = 'DONOR22-TP'
-ACCESS_DEFAULT_SV_NORMAL_FILENAME = 'DONOR22-TP_cl_aln_srt_MD_IR_FX_BR.bam'
+ACCESS_DEFAULT_SV_NORMAL_FILENAME = 'DONOR22-TP_cl_aln_srt_MD_IR_FX_BR.bam$'
 
 
 class AccessLegacySVOperator(Operator):

--- a/runner/operator/access/v1_0_0/structural_variants/__init__.py
+++ b/runner/operator/access/v1_0_0/structural_variants/__init__.py
@@ -54,8 +54,8 @@ class AccessLegacySVOperator(Operator):
 
         # Filter to only tumor bam files
         # Todo: Use separate metadata fields for Tumor / sample ID designation instead of file name
-        standard_tumor_bam_files = [f for p in standard_bam_ports for f in p.value if TUMOR_OR_NORMAL_SEARCH in f['path'].split('/')[-1]]
-        sample_ids = [f['path'].split('/')[-1].split(SAMPLE_ID_SEP)[0] for f in standard_tumor_bam_files]
+        standard_tumor_bam_files = [f for p in standard_bam_ports for f in p.value if TUMOR_OR_NORMAL_SEARCH in f['location'].split('/')[-1]]
+        sample_ids = [f['location'].split('/')[-1].split(SAMPLE_ID_SEP)[0] for f in standard_tumor_bam_files]
 
         sample_inputs = []
         for i, b in enumerate(standard_tumor_bam_files):

--- a/runner/operator/access/v1_0_0/structural_variants/__init__.py
+++ b/runner/operator/access/v1_0_0/structural_variants/__init__.py
@@ -36,7 +36,7 @@ class AccessLegacySVOperator(Operator):
         # Get the latest completed bam generation run for the given request ID
         group_id = Run.objects.filter(
             tags__requestId=self.request_id,
-            app='access legacy',
+            app__name='access legacy',
             status=RunStatus.COMPLETED
         ).order_by('-finished_date').first().job_group
 


### PR DESCRIPTION
I've encountered an error whereby QC files such as `C-DDK2LJ-L003-d_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX-duplex.bam.fragment-sizes` are found instead of the bam files, so I've included the `$` terminator in the file path_regex to avoid this issue.

