### PR TITLE
Add retries to runs

### DIFF
--- a/runner/tasks.py
+++ b/runner/tasks.py
@@ -272,9 +272,17 @@ def process_triggers():
             operator_run.fail()
 
 
-@shared_task
+def on_failure_to_create_run_task(self, exc, task_id, args, kwargs, einfo):
+    run_id = args[0]
+    fail_job(run_id, "Could not create run task")
+
+@shared_task(autoretry_for=(Exception,),
+             retry_jitter=True,
+             retry_backoff=60,
+             retry_kwargs={"max_retries": 4},
+             on_failure=on_failure_to_create_run_task)
 def create_run_task(run_id, inputs, output_directory=None):
-    logger.info("Creating and validating Run")
+    logger.info("Creating and validating Run for %s" % run_id)
     try:
         run = RunObject.from_cwl_definition(run_id, inputs)
         run.ready()
@@ -292,14 +300,7 @@ def create_run_task(run_id, inputs, output_directory=None):
 def on_failure_to_submit_job(self, exc, task_id, args, kwargs, einfo):
     run_id = args[0]
 
-    try:
-        run = Run.objects.get(id=run_id)
-    except Run.DoesNotExist:
-        raise Exception("Could not find run_id %s" % run_id)
-
-    logger.error("Failed to submit job to Ridgeback %s" % run_id)
-    run.status = RunStatus.FAILED
-    run.save()
+    fail_job(run_id, "Failed to submit job to Ridgeback")
 
 @shared_task(autoretry_for=(Exception,),
              retry_jitter=True,


### PR DESCRIPTION
The first retry handles runs failing due to too many DB connections. We should look to implement Ian's suggestion of using a DB Connection pool to fix this.

The other task handles situations where Ridgeback isn't responding.