### PR TITLE
Choose latest bam if multiple matches found (MSI workflow fix)

### DIFF
--- a/runner/operator/access/v1_0_0/msi/__init__.py
+++ b/runner/operator/access/v1_0_0/msi/__init__.py
@@ -66,13 +66,13 @@ class AccessLegacyMSIOperator(Operator):
             sample_regex = r'{}_cl_aln_srt_MD_IR_FX_BR.bam$'.format(tumor_sample_id)
             tumor_bam = FileRepository.filter(file_name_regex=sample_regex)
 
-            if not len(tumor_bam) == 1:
-                msg = 'Found incorrect number of matching bam files ({}) for sample {}'
-                msg = msg.format(len(tumor_bam), tumor_sample_id)
+            if not len(tumor_bam) > 0:
+                msg = 'No matching standard tumor Bam found for sample {}'
+                msg = msg.format(tumor_sample_id)
                 raise Exception(msg)
-                # Todo: if > 1, choose based on run ID
 
-            tumor_bam = tumor_bam[0]
+            tumor_bam = tumor_bam.order_by('-created_date').first()
+
             patient_id = '-'.join(tumor_sample_id.split('-')[0:2])
 
             # Find the matched Normal Standard bam (which could be associated with a different request_id)


### PR DESCRIPTION
@aef- I had put in this logic for the other operators, but I seem to have missed this case for the MSI workflow

Porting things like this to a common location that can be re-used should help to prevent such errors in the future