### PR TITLE
Sort keys when querying for multiple value_lists

### DIFF
--- a/file_system/repository/file_repository.py
+++ b/file_system/repository/file_repository.py
@@ -76,6 +76,7 @@ class FileRepository(object):
         if values_metadata_list:
             values_metadata_query_list = ['metadata__%s' % single_metadata for single_metadata in values_metadata_list]
             values_metadata_query_set = set(values_metadata_query_list)
-            return queryset.values_list(*values_metadata_query_set).order_by(values_metadata_query_list[0]).distinct()
+            sorted_metadata_query_list = sorted(values_metadata_query_set)
+            return queryset.values_list(*sorted_metadata_query_list).order_by(sorted_metadata_query_list[0]).distinct()
 
         return queryset

--- a/runner/views/run_api_view.py
+++ b/runner/views/run_api_view.py
@@ -110,7 +110,8 @@ class RunApiViewSet(mixins.ListModelMixin,
                 else:
                     values_run_query_list = [single_run for single_run in values_run ]
                     values_run_query_set = set(values_run_query_list)
-                    queryset = queryset.values_list(*values_run_query_set).distinct()
+                    sorted_query_list = sorted(values_run_query_set)
+                    queryset = queryset.values_list(*sorted_query_list).distinct()
             if run_distribution:
                 distribution_dict = {}
                 run_query = run_distribution


### PR DESCRIPTION
Enforces ordering in the list returned when using multiple fields in value_lists. 
