### PR TITLE
Disable server side cursors

### DIFF
--- a/beagle/settings.py
+++ b/beagle/settings.py
@@ -193,7 +193,8 @@ DATABASES = {
         'PASSWORD': DB_PASSWORD,
         'HOST': DB_HOST,
         'PORT': DB_PORT,
-        'CONN_MAX_AGE': DB_CONN_MAX_AGE
+        'CONN_MAX_AGE': DB_CONN_MAX_AGE,
+        'DISABLE_SERVER_SIDE_CURSORS': True
     }
 }
 


### PR DESCRIPTION
# What's happening?
Because so many of our workers take a while to finish a task, I set PGBouncer pooling type to `transaction`.
> A server connection is assigned to a client only during a transaction. When PgBouncer notices that the transaction is over, the server will be put back into the pool. 

As opposed to the default, `session`

> Most polite method. When a client connects, a server connection will be assigned to it for the whole duration it stays connected. When the client disconnects, the server connection will be put back into pool. This mode supports all PostgeSQL features.

But this prevents some features from being used by Django ORM, including cursors, which we use, although we don't have to.
https://www.pgbouncer.org/features.html

This is a fix for this issue.
https://docs.djangoproject.com/en/3.0/ref/databases/#transaction-pooling-and-server-side-cursors