### PR TITLE
Ij/fix restart output dir

### DIFF
--- a/runner/views/run_api_view.py
+++ b/runner/views/run_api_view.py
@@ -252,18 +252,13 @@ class RunApiRestartViewSet(GenericAPIView):
             r.save()
 
             # Copy over the input / output ports from the original Run
-            ports = r.port_set.filter(port_type=PortType.INPUT)
+            ports = r.port_set.all()
             for p in ports:
                 files = p.files.all()
                 p.pk = None
                 p.run_id = r.pk
                 p.save()
                 p.files.add(*files)
-            ports = r.port_set.filter(port_type=PortType.OUTPUT)
-            for p in ports:
-                p.pk = None
-                p.run_id = r.pk
-                p.save()
 
             submit_job.delay(r.pk, r.output_directory)
             self._send_notifications(o.job_group_notifier_id, r)


### PR DESCRIPTION
using the /restart endpoint requires that the new Run object has output Ports to iterate through so that outputs can be registered:
```
    def complete(self, outputs):
        for out in self.outputs: 
            out.complete(outputs.get(out.name, None), self.output_file_group, self.job_group_notifier, self.output_metadata)
```