### PR TITLE
Pull request id from previous runs when available

### DIFF
--- a/runner/fixtures/runner.run.json
+++ b/runner/fixtures/runner.run.json
@@ -38,7 +38,7 @@
             "name": "ARGOS JOB 3",
             "app": "cb5d793b-e650-4b7d-bfcd-882858e29cc5",
             "operator_run": 1,
-            "tags": {},
+            "tags": {"tag": "value", "requestId": "request3"},
             "status": 0,
             "execution_id": null,
             "notify_for_outputs": "[]"
@@ -53,7 +53,7 @@
             "name": "INDIVIDUAL ARGOS JOB 1",
             "app": "cb5d793b-e650-4b7d-bfcd-882858e29cc5",
             "operator_run": 2,
-            "tags": {},
+            "tags": {"tag": "value", "requestId": "request4"},
             "status": 0,
             "execution_id": null,
             "notify_for_outputs": "[]"
@@ -68,7 +68,7 @@
             "name": "INDIVIDUAL ACCESS JOB 2",
             "app": "cb5d793b-e650-4b7d-bfcd-882858e29cc5",
             "operator_run": 2,
-            "tags": {},
+            "tags": {"tag": "value"},
             "status": 0,
             "execution_id": null,
             "notify_for_outputs": "[]"
@@ -83,7 +83,7 @@
             "name": "INDIVIDUAL ACCESS JOB 3",
             "app": "cb5d793b-e650-4b7d-bfcd-882858e29cc5",
             "operator_run": 2,
-            "tags": {},
+            "tags": {"tag": "value", "requestId": "request6"},
             "status": 0,
             "execution_id": null,
             "notify_for_outputs": "[]"
@@ -98,7 +98,7 @@
             "name": "INDIVIDUAL ACCESS OPERATOR 2 JOB 1",
             "app": "cb5d793b-e650-4b7d-bfcd-882858e29cc5",
             "operator_run": 3,
-            "tags": {},
+            "tags": {"tag": "value", "requestId": "request7"},
             "status": 0,
             "execution_id": null,
             "notify_for_outputs": "[]"

--- a/runner/operator/operator.py
+++ b/runner/operator/operator.py
@@ -1,5 +1,6 @@
 import logging
 from file_system.models import File, FileMetadata
+from runner.models import Run
 from file_system.repository.file_repository import FileRepository
 from runner.serializers import OperatorErrorSerializer, APIRunCreateSerializer
 from django.db.models import Prefetch
@@ -15,7 +16,6 @@ class Operator(object):
             raise Exception("Must pass an instance of beagle_etl.models.Operator")
 
         self.model = model
-        self.request_id = request_id
         self.job_group_id = job_group_id
         self.job_group_notifier_id = job_group_notifier_id
         self.run_ids = run_ids
@@ -25,6 +25,12 @@ class Operator(object):
         self.output_directory_prefix = output_directory_prefix
         self._jobs = []
         self._pipeline = pipeline
+        self.request_id = request_id
+
+        if not request_id and self.run_ids:
+            run = Run.objects.get(pk=self.run_ids[0])
+            if run.tags.get('requestId'):
+                self.request_id = run.tags.get('requestId')
 
     def get_pipeline_id(self):
         if self._pipeline:

--- a/runner/tests/views/test_run_api_view.py
+++ b/runner/tests/views/test_run_api_view.py
@@ -71,7 +71,7 @@ class TestRunAPIList(APITestCase):
         url = self.api_root + '?tags=tag:value'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()['count'], 3)
+        self.assertEqual(response.json()['count'], 8)
 
     def test_date(self):
         url = self.api_root + '?created_date_gt=2019-10-08T00:00'


### PR DESCRIPTION
Instead of having to go fishing for the `request_id` in the operator, if the first run in a chain has a `requestId` tag set, we should just pass it along to downstream operators that were triggered