### PR TITLE
Admin tweaks/updates

### DIFF
--- a/runner/admin.py
+++ b/runner/admin.py
@@ -57,17 +57,6 @@ class StatusFilter(admin.SimpleListFilter):
             return queryset.filter(status=self.value())
         return queryset
 
-def restart_operator_run(modeladmin, request, queryset):
-    operator_run_groups = set()
-    for run in queryset:
-        operator_run_groups.add(run.operator_run_id)
-
-    #RunApiRestartViewSet(GenericAPIView):
-
-
-
-restart_operator_run.short_description = "Restart Operator Run"
-
 def abort_run(modeladmin, request, queryset):
     jobs = list(queryset.values_list("id"))
     updated = len(jobs)
@@ -85,7 +74,8 @@ class RunAdmin(admin.ModelAdmin):
                     'status', 'link_to_ridgeback', 'created_date', 'finished_date')
     ordering = ('-created_date',)
     list_filter = (('created_date', DateTimeRangeFilter), StatusFilter, AppFilter,)
-    search_fields = ('tags__sampleId', 'tags__requestId', 'tags__cmoSampleIds__contains')
+    search_fields = ('tags__sampleId', 'tags__requestId', 'tags__cmoSampleIds__contains',
+                     'operator_run_id')
     readonly_fields = ('samples', 'job_group', 'job_group_notifier', link_relation('operator_run'),
                        link_relation('app'))
 

--- a/runner/admin.py
+++ b/runner/admin.py
@@ -1,7 +1,14 @@
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.urls import reverse
+from django.utils.translation import ngettext
 from .models import Pipeline, Run, Port, ExecutionEvents, OperatorRun, OperatorTrigger, RunStatus
 from lib.admin import link_relation, progress_bar, pretty_python_exception
 from rangefilter.filter import DateTimeRangeFilter
+from django.utils.html import format_html
+from beagle.settings import RIDGEBACK_URL, BEAGLE_URL
+from runner.tasks import abort_job_task
+import requests
+
 
 class PipelineAdmin(admin.ModelAdmin):
     list_display = ('id', 'name', 'version', 'default', 'output_directory', link_relation("operator"))
@@ -35,10 +42,14 @@ class StatusFilter(admin.SimpleListFilter):
     parameter_name = 'status'
 
     def lookups(self, request, model_admin):
-        # TODO support range/q
+        # TODO support range in status count
         filters = {k:v for (k, v) in request.GET.items() if "range" not in k and "status" not in k
                    and "q" not in k and "p" not in k}
+
         qs = model_admin.get_queryset(request).filter(**filters)
+        if request.GET.get("q"):
+            qs, _use_distinct = model_admin.get_search_results(request, qs,
+                                                request.GET.get("q"))
         return [(status.value, "%s (%s)" % (status.name, qs.filter(status=status.value).count())) for status in RunStatus]
 
     def queryset(self, request, queryset):
@@ -46,17 +57,64 @@ class StatusFilter(admin.SimpleListFilter):
             return queryset.filter(status=self.value())
         return queryset
 
+def restart_operator_run(modeladmin, request, queryset):
+    operator_run_groups = set()
+    for run in queryset:
+        operator_run_groups.add(run.operator_run_id)
+
+    #RunApiRestartViewSet(GenericAPIView):
+
+
+
+restart_operator_run.short_description = "Restart Operator Run"
+
+def abort_run(modeladmin, request, queryset):
+    jobs = list(queryset.values_list("id"))
+    updated = len(jobs)
+    abort_job_task.delay(None, jobs)
+    modeladmin.message_user(request, ngettext(
+        '%d job was submitted to be cancelled',
+        '%d jobs were submitted to be cancelled',
+        updated,
+    ) % updated, messages.SUCCESS)
+
+abort_run.short_description = "Abort Run"
 
 class RunAdmin(admin.ModelAdmin):
-    list_display = ('id', 'name', link_relation("app"), link_relation("operator_run"), 'tags', 'status', 'execution_id', 'created_date', 'notify_for_outputs')
+    list_display = ('id', 'name', link_relation("app"), link_relation("operator_run"), 'tags',
+                    'status', 'link_to_ridgeback', 'created_date', 'finished_date')
     ordering = ('-created_date',)
     list_filter = (('created_date', DateTimeRangeFilter), StatusFilter, AppFilter,)
     search_fields = ('tags__sampleId', 'tags__requestId', 'tags__cmoSampleIds__contains')
-    readonly_fields = ('samples', 'job_group', 'job_group_notifier', 'operator_run', 'app')
+    readonly_fields = ('samples', 'job_group', 'job_group_notifier', link_relation('operator_run'),
+                       link_relation('app'))
+
+    actions = [abort_run]
+
+    def link_to_ridgeback(self, obj):
+        if not obj.execution_id:
+            return "-"
+        return format_html("<a target='_blank' href='{ridgeback_url}/admin/toil_orchestrator/job/{execution_id}'>{execution_id}</a>",
+                           execution_id=obj.execution_id, ridgeback_url=RIDGEBACK_URL)
+    link_to_ridgeback.short_description = "Execution ID (Ridgeback)"
 
 
 class OperatorRunAdmin(admin.ModelAdmin):
-    list_display = ('id', 'status', progress_bar('percent_runs_succeeded'), progress_bar('percent_runs_finished'))
+    list_display = ('id', link_relation("operator"), 'first_run', 'status', 'run_count', progress_bar('percent_runs_succeeded'),
+                    progress_bar('percent_runs_finished'), 'created_date',)
+    ordering = ('-created_date',)
+
+    def run_count(self, obj):
+        return obj.runs.count()
+
+    def first_run(self, obj):
+        run = obj.runs.first()
+        if run:
+            url = reverse('admin:{}_{}_change'.format(obj._meta.app_label, "run"),
+                          args=(run.pk,))
+            return format_html("<a href='{url}'>{name}</a>",
+                           url=url, name=run.name)
+
     def has_change_permission(self, request, obj=None):
         return False
 
@@ -75,10 +133,6 @@ class PortAdmin(admin.ModelAdmin):
         return False
     def has_change_permission(self, request, obj=None):
         return False
-
-
-
-
 
 admin.site.register(Run, RunAdmin)
 admin.site.register(Port, PortAdmin)

--- a/runner/models.py
+++ b/runner/models.py
@@ -93,6 +93,9 @@ class OperatorRun(BaseModel):
     finished_date = models.DateTimeField(blank=True, null=True, db_index=True)
     parent = models.ForeignKey('self', default=None, null=True, blank=True, on_delete=models.SET_NULL)
 
+    def __str__(self):
+        return str(self.pk)
+
     def save(self, *args, **kwargs):
         if self.status == RunStatus.COMPLETED or self.status == RunStatus.FAILED:
             if not self.finished_date:
@@ -177,6 +180,9 @@ class Run(BaseModel):
         self.original = {
             "status": self.status
         }
+
+    def __str__(self):
+        return str(self.pk)
 
     def clear(self):
         fields_to_clear = ["resume", "finished_date", "started", "output_directory", "message",


### PR DESCRIPTION
Here are a bunch of changes I've been wanting to make for awhile:
* Status counts now include filter
* Can now filter by operator run on the runs page
* Added fields to operator run list page in order to identify which operator the operator run is for
* Execution id links out to Ridgeback job page
* Abort through admin page