### PR TITLE
Ensure that running status in Beagle means it's running in Ridgeback

### DIFF
--- a/runner/tasks.py
+++ b/runner/tasks.py
@@ -350,7 +350,6 @@ def submit_job(run_id, output_directory=None):
         response = requests.post(url, json=job)
     if response.status_code == 201:
         run.execution_id = response.json()['id']
-        run.status = RunStatus.RUNNING
         logger.info("Job %s successfully submitted with id:%s" % (run_id, run.execution_id))
         run.save()
     else:
@@ -480,13 +479,15 @@ def _job_finished_notify(run):
 
 
 def running_job(run):
-    run.status = RunStatus.RUNNING
-    run.save()
+    if run.status != RunStatus.RUNNING:
+        run.status = RunStatus.RUNNING
+        run.save()
 
 
 def abort_job(run):
-    run.status = RunStatus.ABORTED
-    run.save()
+    if run.status != RunStatus.ABORTED:
+        run.status = RunStatus.ABORTED
+        run.save()
 
 
 def update_commandline_job_status(run, commandline_tool_job_set):
@@ -505,7 +506,8 @@ def check_job_timeouts():
     TIMEOUT_BY_DAYS = 3
     diff = datetime.now()-timedelta(days=TIMEOUT_BY_DAYS)
     runs = Run.objects.filter(status__in=(RunStatus.CREATING, RunStatus.READY),
-                              created_date__lte=diff).all()
+                              created_date__lte=diff,
+                              execution_id__isnull=True).all()
 
     for run in runs:
         fail_job(run.id, "Run timedout after %s days" % TIMEOUT_BY_DAYS)
@@ -551,7 +553,13 @@ def check_jobs_status():
                 logger.info("Job %s [%s] COMPLETED" % (run.id, run.execution_id))
                 complete_job(str(run.id), status['outputs'])
                 continue
-            if status['status'] == 'CREATED' or status['status'] == 'PENDING' or status['status'] == 'RUNNING':
+            if status['status'] == 'CREATED':
+                logger.info("Job %s [%s] CREATED" % (run.id, run.execution_id))
+                continue
+            if status['status'] == 'PENDING':
+                logger.info("Job %s [%s] PENDING" % (run.id, run.execution_id))
+                continue
+            if status['status'] == 'RUNNING':
                 logger.info("Job %s [%s] RUNNING" % (run.id, run.execution_id))
                 running_job(run)
                 continue


### PR DESCRIPTION
Let's leave Runs as CREATED/READY until they're actually RUNNING in Ridgeback. I'm not sure if this will have any effect on Seqosystem -- @nikhil what do you think?

Essentially I want to be able to see what Runs will finish first in Beagle, which atm is a little difficult to do.