### PR TITLE
Add RUN_MODE to data clinical output file, generated in notifier helper

### DIFF
--- a/notifier/helper.py
+++ b/notifier/helper.py
@@ -10,7 +10,7 @@ def get_project_id(request_id):
 
 
 def generate_sample_data_content(files, pipeline_name, pipeline_github, pipeline_version):
-    result = "SAMPLE_ID\tREQUEST_ID\tPROJECT_ID\tPATIENT_ID\tCOLLAB_ID\tSAMPLE_TYPE\tGENE_PANEL\tONCOTREE_CODE\tSAMPLE_CLASS\tSPECIMEN_PRESERVATION_TYPE\tSEX\tTISSUE_SITE\tIGO_ID\tPIPELINE\tPIPELINE_GITHUB_LINK\tPIPELINE_VERSION\n"
+    result = "SAMPLE_ID\tREQUEST_ID\tPROJECT_ID\tPATIENT_ID\tCOLLAB_ID\tSAMPLE_TYPE\tGENE_PANEL\tONCOTREE_CODE\tSAMPLE_CLASS\tSPECIMEN_PRESERVATION_TYPE\tSEX\tTISSUE_SITE\tIGO_ID\tRUN_MODE\tPIPELINE\tPIPELINE_GITHUB_LINK\tPIPELINE_VERSION\n"
     ret_str = 'metadata__sampleId'
     query = Q(file__file_group_id=settings.IMPORT_FILE_GROUP)
     query |= Q(file__file_group__slug="origin-unknown")
@@ -32,6 +32,7 @@ def generate_sample_data_content(files, pipeline_name, pipeline_github, pipeline
             MetadataValidator.clean_value(metadata['sex']),
             MetadataValidator.clean_value(metadata['tissueLocation']),
             metadata['sampleId'],
+            MetadataValidator.clean_value(metadata['runMode']),
             pipeline_name,
             pipeline_github,
             pipeline_version,


### PR DESCRIPTION
Added `RUN_MODE` to data clinical text output file. This will show if a sample is 

Downstream steps may need to be updated to accomodate this change, but this provides the necessary information requested and can be tuned in the future.