### PR TITLE
Add pipeline version to pairs operator for argos

### DIFF
--- a/runner/serializers.py
+++ b/runner/serializers.py
@@ -368,6 +368,9 @@ class PairOperatorSerializer(serializers.Serializer):
     pipelines = serializers.ListField(
         child=serializers.CharField(max_length=30), allow_empty=True
     )
+    pipeline_versions = serializers.ListField(
+        child=serializers.CharField(max_length=30), allow_empty=True
+    )
     name = serializers.CharField(allow_blank=False, allow_null=False)
     output_directory_prefix = serializers.CharField(max_length=50, allow_blank=True, allow_null=True)
     job_group_id = serializers.UUIDField(required=False)

--- a/runner/views/run_api_view.py
+++ b/runner/views/run_api_view.py
@@ -447,6 +447,7 @@ class PairsOperatorViewSet(GenericAPIView):
     def post(self, request):
         pairs = request.data.get('pairs')
         pipeline_names = request.data.get('pipelines')
+        pipeline_versions = request.data.get('pipeline_versions')
         name = request.data.get('name')
         job_group_id = request.data.get('job_group_id', None)
         output_directory_prefix = request.data.get('output_directory_prefix', None)
@@ -456,8 +457,9 @@ class PairsOperatorViewSet(GenericAPIView):
             job_group.save()
             job_group_id = str(job_group.id)
 
-        for pipeline_name in pipeline_names:
-            pipeline = get_object_or_404(Pipeline, name=pipeline_name)
+        for i,pipeline_name in enumerate(pipeline_names):
+            pipeline_version = pipeline_versions[i]
+            pipeline = get_object_or_404(Pipeline, name=pipeline_name, version=pipeline_version)
 
             try:
                 job_group_notifier = JobGroupNotifier.objects.get(job_group_id=job_group_id,


### PR DESCRIPTION
Updating the argos manual pairing view/serializer to accept pipeline versions