### PR TITLE
Tempo mpgen operator/write directly to pipeline output dir

### DIFF
--- a/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
+++ b/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
@@ -72,9 +72,11 @@ class TempoMPGenOperator(Operator):
 
     def get_jobs(self, pairing_override=None):
         logger.info("Operator JobGroupNotifer ID %s", self.job_group_notifier_id)
-        tmpdir = os.path.join(settings.BEAGLE_SHARED_TMPDIR, str(uuid.uuid4()))
-        self.OUTPUT_DIR = tmpdir 
-        Path(self.OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+        app = self.get_pipeline_id()
+        pipeline = Pipeline.objects.get(id=app)
+        pipeline_version = pipeline.version
+        output_directory = pipeline.output_directory
+        self.OUTPUT_DIR = output_directory
 
         recipe_query = self.build_recipe_query()
         assay_query = self.build_assay_query()
@@ -154,24 +156,15 @@ class TempoMPGenOperator(Operator):
         tags = {"beagle_version": beagle_version,
                 "run_date" : run_date}
 
-        app = self.get_pipeline_id()
-        pipeline = Pipeline.objects.get(id=app)
-        pipeline_version = pipeline.version
-        output_directory = pipeline.output_directory
+        self.send_message("""
+            Writing files to {file_path}.
 
-        self.debug_json = input_json
-
-        tempo_mpgen_outputs_job_data = {
-            'app': app,
-            'inputs': input_json,
-            'name': "Tempo mpgen %s" % run_date,
-            'tags': tags,
-            'output_directory': output_directory
-       }
-
-        tempo_mpgen_outputs_job = [(APIRunCreateSerializer(
-            data=tempo_mpgen_outputs_job_data), input_json)]
-        return tempo_mpgen_outputs_job
+            Run Date: {run_date}
+            Beagle Version: {beagle_version}
+            """.format(file_path=self.OUTPUT_DIR,
+                       run_date=run_date,
+                       beagle_version=beagle_version)
+                )
 
 
     def load_pairing_file(self, tsv_file):

--- a/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
+++ b/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
@@ -166,6 +166,8 @@ class TempoMPGenOperator(Operator):
                        beagle_version=beagle_version)
                 )
 
+        return []
+
 
     def load_pairing_file(self, tsv_file):
         pairing = dict()


### PR DESCRIPTION
Instead of writing to a temp directory then moving the files over using a Run, this change writes the files directly into the pipeline output directory.

We lose a db backend recording of the execution (i.e., we don't create a Run object saying the files were moved), but the JIRA ticket created by the operators still exist and serves a similar function. The loss is also not critical since the code executes daily.