### PR TITLE
Reduce # of requests sent to ELK

### DIFF
--- a/beagle/settings.py
+++ b/beagle/settings.py
@@ -91,9 +91,10 @@ ELASTIC_APM = {
   # Set the required service name. Allowed characters:
   # a-z, A-Z, 0-9, -, _, and space
   'SERVICE_NAME': 'beagle',
-
+  'TRANSACTION_SAMPLE_RATE': 0.3,
   # Use if APM Server requires a secret token
   #'SECRET_TOKEN': '',
+
 
   # Set the custom APM Server URL (default: http://localhost:8200)
   'SERVER_URL': 'http://bic-dockerapp01.mskcc.org:8200/',


### PR DESCRIPTION
Currently we're sending every request and I'm seeing the following in logs:

```
[2021-06-25 14:03:59,517: ERROR/ForkPoolWorker-3] Failed to submit message: 'HTTP 503: {"accepted":0,"errors":[{"message":"queue is full"}]}\n'
Traceback (most recent call last):
  File "/home/voyager/.local/lib/python3.7/site-packages/elasticapm/transport/base.py", line 228, in _flush
    self.send(data)
  File "/home/voyager/.local/lib/python3.7/site-packages/elasticapm/transport/http.py", line 111, in send
    raise TransportException(message, data, print_trace=print_trace)
elasticapm.transport.exceptions.TransportException: HTTP 503: {"accepted":0,"errors":[{"message":"queue is full"}]}
```

It's hard to say what the magic number is, so hopefully 0.3 is conservative.