### PR TITLE
Make sure input failures in the Operators are reported to JIRA

### DIFF
--- a/runner/operator/access/v1_0_0/legacy/__init__.py
+++ b/runner/operator/access/v1_0_0/legacy/__init__.py
@@ -157,7 +157,7 @@ def construct_sample_inputs(samples, request_id, group_id):
             missing_fields = get_missing_fields(meta, REQUIRED_META_FIELDS)
             if missing_fields:
                 ic_error = InputCreationFailedEvent(
-                    "The following fields are missing from the input: {}".format(",".join(missing_fields)),
+                    "The following fields are missing from the metadata: {}".format(",".join(missing_fields)),
                     group_id,
                     request_id,
                     meta["sampleId"]

--- a/runner/tasks.py
+++ b/runner/tasks.py
@@ -33,6 +33,11 @@ def create_jobs_from_operator(operator, job_group_id=None, job_group_notifier_id
 def create_operator_run_from_jobs(operator, jobs, job_group_id=None, job_group_notifier_id=None, parent=None):
     jg = None
     jgn = None
+
+    if not jobs:
+        logger.info("Could not create operator run due to no jobs being passed")
+        return
+
     try:
         jg = JobGroup.objects.get(id=job_group_id)
         logger.info("JobGroup id: %s", job_group_id)


### PR DESCRIPTION
There are situations in which an operator may not return anything -- we don't want the task to error out.