### PR TITLE
Fixed sample mapping output generator for argos operator 1.1.3

### DIFF
--- a/runner/operator/argos_operator/v1_1_3/argos_operator.py
+++ b/runner/operator/argos_operator/v1_1_3/argos_operator.py
@@ -117,7 +117,7 @@ class ArgosOperator(Operator):
                     files.append(filepath)
             for p in job['pair'][0]['bam']:
                 filepath = FileProcessor.parse_path_from_uri(p['location'])
-                file_str = "\t".join([normal_sample_name, filepath]) + "\n"
+                file_str = "\t".join([tumor_sample_name, filepath]) + "\n"
                 if file_str not in check_for_duplicates:
                     check_for_duplicates.append(file_str)
                     sample_mapping += file_str
@@ -140,8 +140,6 @@ class ArgosOperator(Operator):
                     check_for_duplicates.append(file_str)
                     sample_mapping += file_str
                 if filepath not in files:
-                    sample_mapping += "\t".join(
-                        [normal_sample_name, filepath]) + "\n"
                     files.append(filepath)
             for p in job['pair'][1]['zR1']:
                 filepath = FileProcessor.parse_path_from_uri(p['location'])


### PR DESCRIPTION
R2 pooled normals were being duplicated in mapping files; removed conflicting code.

Also adjusted tumor sample bam mapping string generator - it had `normal_sample_name` in there.