### PR TITLE
Allan/fix sample tracker

### DIFF
--- a/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
+++ b/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
@@ -394,11 +394,11 @@ class TempoMPGenOperator(Operator):
         return self.write_to_file("sample_tracker.txt", tracker)
 
     def _get_investigator_id(self, d):
-    '''
-    externalSampleId was deprecated and is no longer
-    included in new imports; need to return investigatorId value in sampleAliases
-    instead
-    '''
+        """ 
+        externalSampleId was deprecated and is no longer
+        included in new imports; need to return investigatorId value in sampleAliases
+        instead
+        """
         if 'externalSampleId' in d:
             return d['externalSampleId']
         sample_aliases = d['sampleAliases']

--- a/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
+++ b/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
@@ -394,12 +394,17 @@ class TempoMPGenOperator(Operator):
         return self.write_to_file("sample_tracker.txt", tracker)
 
     def _get_investigator_id(self, d):
-    # externalSampleId was deprecated; need to return investigatorId value in sampleAliases
-        if 'externalSampleId' not in d.keys():
-            sample_aliases = d['sampleAliases']
-            for i in sample_aliases:
-                v = i['value']
-                ns = i['namespace']
-                if ns == 'investigatorId':
-                    return v
+    '''
+    externalSampleId was deprecated and is no longer
+    included in new imports; need to return investigatorId value in sampleAliases
+    instead
+    '''
+        if 'externalSampleId' in d:
+            return d['externalSampleId']
+        sample_aliases = d['sampleAliases']
+        for i in sample_aliases:
+            v = i['value']
+            ns = i['namespace']
+            if ns == 'investigatorId':
+                return v
         return None

--- a/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
+++ b/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
@@ -380,10 +380,25 @@ class TempoMPGenOperator(Operator):
                         running = list()
                         running.append(sample.cmo_sample_name)
                         for key in key_order:
-                            s = self._validate_to_str(meta[key])
+                            if key == 'externalSampleId':
+                                v = self._get_investigator_id(meta)
+                            else:
+                                v = meta[key]
+                            s = self._validate_to_str(v)
                             running.append(s)
                         for key in extra_keys:
                             s = self._validate_to_str(meta[key])
                             running.append(s)
                         tracker += "\t".join(running) + "\n"
         return self.write_to_file("sample_tracker.txt", tracker)
+
+    def _get_investigator_id(self, d):
+    # externalSampleId was deprecated; need to return investigatorId value in sampleAliases
+        if 'externalSampleId' not in d.keys():
+            sample_aliases = d['sampleAliases']
+            for i in sample_aliases:
+                v = i['value']
+                ns = i['namespace']
+                if ns == 'investigatorId':
+                    return v
+        return None

--- a/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
+++ b/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
@@ -5,6 +5,7 @@ import json
 import csv
 import pickle
 import logging
+import unicodedata
 from django.db.models import Q
 from django.conf import settings
 from pathlib import Path

--- a/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
+++ b/runner/operator/tempo_mpgen_operator/tempo_mpgen_operator.py
@@ -381,7 +381,7 @@ class TempoMPGenOperator(Operator):
                         running = list()
                         running.append(sample.cmo_sample_name)
                         for key in key_order:
-                            if key == 'externalSampleId':
+                            if key == "externalSampleId":
                                 v = self._get_investigator_id(meta)
                             else:
                                 v = meta[key]
@@ -394,17 +394,17 @@ class TempoMPGenOperator(Operator):
         return self.write_to_file("sample_tracker.txt", tracker)
 
     def _get_investigator_id(self, d):
-        """ 
+        """
         externalSampleId was deprecated and is no longer
         included in new imports; need to return investigatorId value in sampleAliases
         instead
         """
-        if 'externalSampleId' in d:
-            return d['externalSampleId']
-        sample_aliases = d['sampleAliases']
+        if "externalSampleId" in d:
+            return d["externalSampleId"]
+        sample_aliases = d["sampleAliases"]
         for i in sample_aliases:
-            v = i['value']
-            ns = i['namespace']
-            if ns == 'investigatorId':
+            v = i["value"]
+            ns = i["namespace"]
+            if ns == "investigatorId":
                 return v
         return None


### PR DESCRIPTION
`externalSampleId` isn't being added anymore since we moved over to SMILE

https://github.com/mskcc/beagle/blob/master/beagle_etl/jobs/lims_etl_jobs.py#L734

But the same information is in `sampleAliases` now; this fix uses that if `externalSampleId` doesn't exist in the metadata.