### PR TITLE
Hotfix/access path updates

### DIFF
--- a/runner/operator/access/v1_0_0/legacy/input_template.json.jinja2
+++ b/runner/operator/access/v1_0_0/legacy/input_template.json.jinja2
@@ -34,7 +34,7 @@
     "arrg_path": "juno:///juno/work/access/production/resources/tools/picard/versions/v1.96/picard-tools-1.96/AddOrReplaceReadGroups.jar",
     "gatk_path": "/opt/common/CentOS_6/gatk/GenomeAnalysisTK-3.3-0/GenomeAnalysisTK.jar",
     "waltz_path": "juno:///juno/work/access/production/resources/tools/waltz/versions/v2.0.0/Waltz-2.0.jar",
-    "picard_path": "juno:///juno/work/access/production/resources/tools/picard/versions/v2.8.1/picard.jar",
+    "picard_path": "/juno/work/access/production/resources/tools/picard/versions/v2.8.1/picard.jar",
     "bioinfo_utils": {
       "location": "juno:///juno/work/access/production/resources/tools/voyager_resources/BioinfoUtils-1.0.2.jar",
       "class": "File"

--- a/runner/operator/access/v1_0_0/legacy/input_template.json.jinja2
+++ b/runner/operator/access/v1_0_0/legacy/input_template.json.jinja2
@@ -31,15 +31,15 @@
     "fx_path": "/opt/common/CentOS_6/picard/picard-tools-1.96/FixMateInformation.jar",
     "bwa_path": "/opt/common/CentOS_6/bwa/bwa-0.7.5a/bwa",
     "abra_path": "/opt/common/CentOS_6/abra2/abra2-2.17/abra2-2.17.jar",
-    "arrg_path": "juno:///juno/work/access/production/resources/tools/picard/versions/v1.96/picard-tools-1.96/AddOrReplaceReadGroups.jar",
+    "arrg_path": "/juno/work/access/production/resources/tools/picard/versions/v1.96/picard-tools-1.96/AddOrReplaceReadGroups.jar",
     "gatk_path": "/opt/common/CentOS_6/gatk/GenomeAnalysisTK-3.3-0/GenomeAnalysisTK.jar",
-    "waltz_path": "juno:///juno/work/access/production/resources/tools/waltz/versions/v2.0.0/Waltz-2.0.jar",
+    "waltz_path": "/juno/work/access/production/resources/tools/waltz/versions/v2.0.0/Waltz-2.0.jar",
     "picard_path": "/juno/work/access/production/resources/tools/picard/versions/v2.8.1/picard.jar",
     "bioinfo_utils": {
       "location": "juno:///juno/work/access/production/resources/tools/voyager_resources/BioinfoUtils-1.0.2.jar",
       "class": "File"
     },
-    "marianas_path": "juno:///juno/work/access/production/resources/tools/marianas/versions/v1.8.0/Marianas-1.8.0.jar",
+    "marianas_path": "/juno/work/access/production/resources/tools/marianas/versions/v1.8.0/Marianas-1.8.0.jar",
     "trimgalore_path": "/opt/common/CentOS_6/trim_galore/Trim_Galore_v0.2.5/trim_galore"
   },
   "inputs_yaml": {

--- a/runner/operator/access/v1_0_0/snps_and_indels/input_template.json.jinja2
+++ b/runner/operator/access/v1_0_0/snps_and_indels/input_template.json.jinja2
@@ -144,7 +144,7 @@
       "bcftools": "/opt/common/CentOS_7-dev/bin/bcftools",
       "gbcms": "/juno/work/access/production/resources/tools/GetBaseCountsMultiSample/versions/GetBaseCountsMultiSample-1.2.5/GetBaseCountsMultiSample",
       "java_7": "/opt/common/CentOS_6/java/jdk1.7.0_75/bin/java",
-      "mutect": "juno:///juno/work/access/production/resources/tools/muTect/current/muTect-1.1.5.jar",
+      "mutect": "/juno/work/access/production/resources/tools/muTect/current/muTect-1.1.5.jar",
       "vardict": "/opt/common/CentOS_6-dev/vardict/v1.5.1/bin/VarDict",
       "vardict_testsomatic": "/opt/common/CentOS_6-dev/vardict/v1.5.1/vardict_328e00a/testsomatic.R",
       "vardict_var2vcf_paired": "/opt/common/CentOS_6-dev/vardict/v1.5.1/vardict_328e00a/var2vcf_paired.pl",


### PR DESCRIPTION
✔️  updating path formatting. Some path needs different formatting since it is defined as a `string input` in the cwl and not a `File input`. The ` juno://` suffix should only be used for `File input`. 

PR relates to this original issue: https://github.com/mskcc/beagle/issues/1028