### PR TITLE
Feature/make m1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL:=/bin/bash
 UNAME:=$(shell uname)
+UNAME_P:=$(shell UNAME)_$(shell uname -p)
 CURDIR_BASE:=$(shell basename "$(CURDIR)")
 export LOG_DIR_ABS:=$(shell python -c 'import os; print(os.path.realpath("logs"))')
 
@@ -12,6 +13,8 @@ Basic dev instance setup instructions:
 
 1. install dependencies in the current directory with:
 make install
+
+- NOTE: For an m1 mac, use make `install-m1`, and then activate the virtual environment conda activate beagle
 
 2a. initialize the database with:
 make db-init
@@ -85,8 +88,21 @@ unexport PYTHONPATH
 unexport PYTHONHOME
 
 # install versions of conda for Mac or Linux, Python 2 or 3
+
 ifeq ($(UNAME), Darwin)
-CONDASH:=Miniconda3-4.7.12.1-MacOSX-x86_64.sh
+	ifeq ($(UNAME_P), Darwin_arm)
+	CONDASH:=Miniconda3-latest-MacOSX-arm64.sh
+	endif
+endif
+
+ifeq ($(UNAME), Darwin)
+	ifneq ($(UNAME_P), Darwin_arm)
+	CONDASH:=Miniconda3-4.7.12.1-MacOSX-x86_64.sh
+	endif
+endif
+
+ifeq ($(UNAME), Linux)
+CONDASH:=Miniconda3-4.7.12.1-Linux-x86_64.sh
 endif
 
 ifeq ($(UNAME), Linux)
@@ -113,6 +129,21 @@ install: conda
 	pip install -r requirements-dev.txt
 # pip install git+https://github.com/mskcc/beagle_cli.git@develop
 # pip install -r requirements-cli.txt # <- what happened to this file?
+
+# install the Beagle requirements, m1 friendly 
+install-m1: conda
+	CONDA_SUBDIR=osx-64 conda create -y -n beagle python=3.8
+	$(shell conda/bin/activate beagle && \
+	conda config --system --set subdir osx-64 && \
+	conda install -y \
+		conda-forge::ncurses=6.1 \
+		rabbitmq-server=3.7.16 \
+		anaconda::postgresql=11.2 \
+		conda-forge::python-ldap=3.2.0 \
+		bioconda::rabix-bunny=1.0.4 \
+		conda-forge::jq && \
+		pip install -r requirements.txt && \
+		pip install -r requirements-dev.txt)
 
 export ENVIRONMENT=dev
 # ~~~~~ Set Up Demo Postgres Database for Dev ~~~~~ #

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,11 @@ Basic dev instance setup instructions:
 1. install dependencies in the current directory with:
 make install
 
-- NOTE: For an m1 mac, use make `install-m1`, and then activate the virtual environment conda activate beagle
+1a. For an m1 mac, install dependencies in the current directory with: 
+make install-m1 
+
+Then activate the virtual environment with: 
+conda activate beagle 
 
 2a. initialize the database with:
 make db-init
@@ -87,7 +91,7 @@ PATH:=$(CURDIR)/conda/bin:$(PATH)
 unexport PYTHONPATH
 unexport PYTHONHOME
 
-# install versions of conda for Mac or Linux, Python 2 or 3
+# install versions of conda for Mac, M1 Mac or Linux, Python 2 or 3
 
 ifeq ($(UNAME), Darwin)
 	ifeq ($(UNAME_P), Darwin_arm)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ make install
 make install-m1
 ```
 
-- If using a mac m1, activate the `conda` virtual environment:
+and activate the conda environment: 
 
 ```
 conda activate beagle

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cd beagle
 make install
 ```
 
-- If using a m1 mac, use: 
+- If using a m1 mac, install with: 
 ```
 make install-m1
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cd beagle
 make install
 ```
 
-Or for a m1 mac: 
+- If using a m1 mac, use: 
 ```
 make install-m1
 ```

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ cd beagle
 make install
 ```
 
+Or for a m1 mac: 
+```
+make install-m1
+```
+
+- If using a mac m1, activate the `conda` virtual environment:
+
+```
+conda activate beagle
+```
+
 - Initialize the PostgreSQL database:
 
 ```


### PR DESCRIPTION
@alyvann and I were having some trouble setting up dev instances on our m1 macs. We realized this is because some packages used by `beagle` are only available on x86 macs such as ncurses. This was causing package conflicts since miniconda was mixing m1 and x86 packages together. See this post here: https://stackoverflow.com/questions/65415996/how-to-specify-the-architecture-or-platform-for-a-new-conda-environment-apple. 

This pull request incorporates the solution from the link above into the makefile along with some edits to the documentation. 

@nikhil let me know how things look / what needs to be changed. Also, @alyvann would you mind trying the solution on your machine? Thanks for the help! 