### PR TITLE
Update nucleo_qc_operator.py

### DIFF
--- a/runner/operator/cmo_ch/v2_1_0/qc/nucleo_qc_operator.py
+++ b/runner/operator/cmo_ch/v2_1_0/qc/nucleo_qc_operator.py
@@ -77,7 +77,7 @@ class CMOCHNucleoOperatorQC(Operator):
     def get_nucleo_outputs(self):
         # Test case for if user passed run id, or not
         if not self.request_id:
-            most_recent_runs_for_request = self.run_ids
+            most_recent_runs_for_request = Run.objects.filter(pk__in=self.run_ids)
         else:
             # Use most recent set of runs that completed successfully
             most_recent_runs_for_request = (


### PR DESCRIPTION
Fixed logic for pulling run objects

Follow the same logic we see here:
https://github.com/mskcc/beagle/blob/master/runner/operator/cmo_ch/v2_1_0/qc_agg/nucleo_qc_operator_agg.py#L78