### PR TITLE
Fix/invalid pipeline operator factory

### DIFF
--- a/runner/operator/operator_factory.py
+++ b/runner/operator/operator_factory.py
@@ -23,10 +23,6 @@ class OperatorFactory(object):
         mod_name, func_name = model.class_name.rsplit(".", 1)
         mod = importlib.import_module(mod_name)
         operator_class = getattr(mod, func_name)
-
-        from pprint import pprint
-        for operator_pipeline in model.pipeline_set.all():
-            pprint("pipeline_version is " + operator_pipeline.version)
         if "pipeline_version" in kwargs:
             pipeline_version = kwargs.get("pipeline_version")
             pipeline_exists = any([

--- a/runner/operator/operator_factory.py
+++ b/runner/operator/operator_factory.py
@@ -25,11 +25,13 @@ class OperatorFactory(object):
         operator_class = getattr(mod, func_name)
         if "pipeline_version" in kwargs:
             pipeline_version = kwargs.get("pipeline_version")
-            pipeline_exists = any([
-                p_version_bool in operator_pipeline.version for operator_pipeline in model.pipeline_set.all()
-            ])
+            pipeline_exists = any(
+                [p_version_bool in operator_pipeline.version for operator_pipeline in model.pipeline_set.all()]
+            )
             if not pipeline_exists:
                 raise PipelineNotFoundError(
-                    "Version {pipeline_version} is not found for Pipelines associated with Operator {model_name}"
-                .format(pipeline_version=pipeline_version, model_name=mod_name))
+                    "Version {pipeline_version} is not found for Pipelines associated with Operator {model_name}".format(
+                        pipeline_version=pipeline_version, model_name=mod_name
+                    )
+                )
         return operator_class(model, **kwargs)

--- a/runner/operator/operator_factory.py
+++ b/runner/operator/operator_factory.py
@@ -1,5 +1,6 @@
 import importlib
 from beagle_etl.models import Operator
+from runner.models import Pipeline
 
 
 class OperatorFactory(object):
@@ -22,4 +23,17 @@ class OperatorFactory(object):
         mod_name, func_name = model.class_name.rsplit(".", 1)
         mod = importlib.import_module(mod_name)
         operator_class = getattr(mod, func_name)
+
+        from pprint import pprint
+        for operator_pipeline in model.pipeline_set.all():
+            pprint("pipeline_version is " + operator_pipeline.version)
+        if "pipeline_version" in kwargs:
+            pipeline_version = kwargs.get("pipeline_version")
+            pipeline_exists = any([
+                p_version_bool in operator_pipeline.version for operator_pipeline in model.pipeline_set.all()
+            ])
+            if not pipeline_exists:
+                raise PipelineNotFoundError(
+                    "Version {pipeline_version} is not found for Pipelines associated with Operator {model_name}"
+                .format(pipeline_version=pipeline_version, model_name=mod_name))
         return operator_class(model, **kwargs)

--- a/runner/tests/operator/test_operator_factory.py
+++ b/runner/tests/operator/test_operator_factory.py
@@ -27,4 +27,6 @@ class TestOperatorFactory(TestCase):
         """
         Test that invalid pipelines raise an exception
         """
-        self.assertRaises(Exception, OperatorFactory.get_by_model, Operator.objects.first(), pipeline_version="Does_not_exist")
+        self.assertRaises(
+            Exception, OperatorFactory.get_by_model, Operator.objects.first(), pipeline_version="Does_not_exist"
+        )

--- a/runner/tests/operator/test_operator_factory.py
+++ b/runner/tests/operator/test_operator_factory.py
@@ -27,4 +27,4 @@ class TestOperatorFactory(TestCase):
         """
         Test that invalid pipelines raise an exception
         """
-        self.assertRaises(Exception, OperatorFactory.get_by_model, Operator.objects.first(), version="Does_not_exist")
+        self.assertRaises(Exception, OperatorFactory.get_by_model, Operator.objects.first(), pipeline_version="Does_not_exist")


### PR DESCRIPTION
I think there's a disconnect between the version of the operator and the version of the pipeline.

Based on the test comment here, I'm implementing the fix for that.

https://github.com/mskcc/beagle/blob/5452f9ebd36b3d316c40707f1021d34e497c77a7/runner/tests/operator/test_operator_factory.py#L26-L30