### PR TITLE
CH QC Aggregate Operator Input Fix

### DIFF
--- a/runner/operator/cmo_ch/v2_1_0/qc_agg/nucleo_qc_operator_agg.py
+++ b/runner/operator/cmo_ch/v2_1_0/qc_agg/nucleo_qc_operator_agg.py
@@ -173,7 +173,7 @@ class CMOCHNucleoOperatorQcAgg(Operator):
         This creates a cwl file objects. Opting to use this method in find_biometric_files
         as it seems more consistent with what was in prior input.json(s) for this operator.
         """
-        return {"class": "File", "path": file_path.replace("file://", "", 1)}
+        return {"class": "File", "location": file_path.replace("file://", "juno://", 1)}
 
     def find_biometric_files(self, job_dirs, ending):
         """


### PR DESCRIPTION
Bug: The CH Aggregate QC operator was creating a jobs json that produced an empty input json when submitted to the JobCreator.

The primary causes were:

- Unnecessary processing of cwl directory objects.
- Incorrect formatting for new ports duplex_extraction_files and collapsed_extraction_files cwl file objects
using path instead of location, missing juno:// URI