### PR TITLE
MSI Matching Fix

### DIFF
--- a/runner/operator/access/v1_0_0/msi/__init__.py
+++ b/runner/operator/access/v1_0_0/msi/__init__.py
@@ -60,8 +60,8 @@ class AccessLegacyMSIOperator(Operator):
 
         standard_tumor_bams = [f for p in standard_bam_ports for f in p.files.all() if self.is_tumor_bam(f)]
 
-        sample_ids = []
-        matched_normal_bams = []
+        # Dictionary that associates tumor bam with standard bam with tumor_sample_id
+        sample_tumor_normal = {}
         for standard_tumor_bam in standard_tumor_bams:
             tumor_sample_id = standard_tumor_bam.file_name.split("_cl_aln")[0]
             patient_id = "-".join(tumor_sample_id.split("-")[0:2])
@@ -78,13 +78,13 @@ class AccessLegacyMSIOperator(Operator):
 
             matched_normal_bam = matched_normal_bam.order_by("-created_date").first()
 
-            sample_ids.append(tumor_sample_id)
-            matched_normal_bams.append(matched_normal_bam)
+
+            sample_tumor_normal[tumor_sample_id] = {'normal': matched_normal_bam, 
+                                                    'tumor': standard_tumor_bam}
 
         sample_inputs = [
-            self.construct_sample_inputs(sample_ids[i], standard_tumor_bams[i], matched_normal_bams[i])
-            for i in range(0, len(sample_ids))
-        ]
+                  self.construct_sample_inputs(key, value['tumor'], value['normal'])
+                  for key, value in sample_tumor_normal.items()]
 
         return sample_inputs
 

--- a/runner/operator/access/v1_0_0/msi/__init__.py
+++ b/runner/operator/access/v1_0_0/msi/__init__.py
@@ -78,13 +78,12 @@ class AccessLegacyMSIOperator(Operator):
 
             matched_normal_bam = matched_normal_bam.order_by("-created_date").first()
 
-
-            sample_tumor_normal[tumor_sample_id] = {'normal': matched_normal_bam, 
-                                                    'tumor': standard_tumor_bam}
+            sample_tumor_normal[tumor_sample_id] = {"normal": matched_normal_bam, "tumor": standard_tumor_bam}
 
         sample_inputs = [
-                  self.construct_sample_inputs(key, value['tumor'], value['normal'])
-                  for key, value in sample_tumor_normal.items()]
+            self.construct_sample_inputs(key, value["tumor"], value["normal"])
+            for key, value in sample_tumor_normal.items()
+        ]
 
         return sample_inputs
 


### PR DESCRIPTION
Request `13893_F` revealed that the MSI operator was mismatching normal and tumor bams for a given sample. See the following example run: http://voyager:5007/admin/runner/run/189a593c-d56b-11ed-98e3-ac1f6bb4ad16/change/?_changelist_filters=q%3D13893_F%26app%3D48008842-625e-4af5-827f-fb4b92d7e0e7

When the operator hit the [missing normal case](https://github.com/mskcc/beagle/blob/feature/nucleo_qc_op/runner/operator/access/v1_0_0/msi/__init__.py#L74-L77), it did not adjust the [tumor bam list](https://github.com/mskcc/beagle/blob/feature/nucleo_qc_op/runner/operator/access/v1_0_0/msi/__init__.py#L61), causing the mismatch. As a result, the tumor bam list would be longer than the normal list, which caused tumors and normals to be mismatched when [generating cwl inputs](https://github.com/mskcc/beagle/blob/feature/nucleo_qc_op/runner/operator/access/v1_0_0/msi/__init__.py#L85.).

To fix, I restructured the three lists (tumor sample ids, tumor bams, normal bams) into a dictionary that makes the association between tumor sample id, tumor bam and normal bam explicit.  

TODO: add a better notification when samples don't have matched normals. Right now, this is simply sent to standard out via the logger. 