### PR TITLE
Feature/pairing refactor

### DIFF
--- a/runner/operator/access/heme/nucleo/heme_nucleo.py
+++ b/runner/operator/access/heme/nucleo/heme_nucleo.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from collections import defaultdict
 
 from runner.operator.operator import Operator
+from runner.operator.helper import pair_samples
 from runner.run.objects.run_creator_object import RunCreator
 from file_system.repository.file_repository import FileRepository
 
@@ -85,7 +86,7 @@ def construct_sample_inputs(samples, request_id):
         sample_group = list(sample_group)
         sample_id = sample_group[0]["metadata"][settings.CMO_SAMPLE_NAME_METADATA_KEY]
 
-        fgbio_fastq_to_bam_input = group_by_run(sample_group)
+        fgbio_fastq_to_bam_input = pair_samples(sample_group)
         fgbio_fastq_to_bam_input = [
             [
                 {"class": "File", "location": "juno://" + s[0]["path"]},

--- a/runner/operator/access/v2_1_0/nucleo/access_nucleo.py
+++ b/runner/operator/access/v2_1_0/nucleo/access_nucleo.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from collections import defaultdict
 
 from runner.operator.operator import Operator
+from runner.operator.helper import pair_samples
 from runner.run.objects.run_creator_object import RunCreator
 from file_system.repository.file_repository import FileRepository
 
@@ -42,39 +43,6 @@ def group_by_sample_id(samples):
     sample_pairs = defaultdict(list)
     for sample in samples:
         sample_pairs[sample["metadata"][settings.SAMPLE_ID_METADATA_KEY]].append(sample)
-    return sample_pairs
-
-
-def pair_samples(fastqs):
-    """
-    pair sample fastqs based on the delivery directory.
-
-    Parameters:
-        fastqs (list): A list of sample fastq files.
-
-    Returns:
-        list: A list of tuples containing paired fastqs for a sample
-    """
-    sample_pairs = []
-    expected_pair = set(["R1", "R2"])
-    # match R1 and R2 based on delivery directory
-    # sorting on file names is not enough as they are non-unique
-    for i, fastq in enumerate(fastqs):
-        dir = "/".join(fastq["path"].split("/")[0:-1])
-        for compare in fastqs[i + 1 :]:
-            compare_dir = "/".join(compare["path"].split("/")[0:-1])
-            if dir == compare_dir:
-                # check if R1 and R2 are present
-                r_check = set([fastq["metadata"]["R"], compare["metadata"]["R"]])
-                if r_check.issubset(expected_pair):
-                    # Keep ordering consistent
-                    if fastq["metadata"]["R"] == "R1":
-                        sample_pairs.append((fastq, compare))
-                    else:
-                        sample_pairs.append((compare, fastq))
-                else:
-                    sample_name = fastq["metadata"]["cmoSampleName"]
-                    raise Exception(f"Improper pairing for: {sample_name}")
     return sample_pairs
 
 

--- a/runner/operator/cmo_ch/v2_1_0/nucleo/nucleo_operator.py
+++ b/runner/operator/cmo_ch/v2_1_0/nucleo/nucleo_operator.py
@@ -6,6 +6,7 @@ from jinja2 import Template
 from collections import defaultdict
 
 from runner.operator.operator import Operator
+from runner.operator.helper import pair_samples
 from runner.run.objects.run_creator_object import RunCreator
 from file_system.repository.file_repository import FileRepository
 from django.conf import settings
@@ -57,9 +58,9 @@ def pair_samples(fastqs):
     # match R1 and R2 based on delivery directory
     # sorting on file names is not enough as they are non-unique
     for i, fastq in enumerate(fastqs):
-        dir = "/".join(fastq["path"].split("/")[0:-1])
+        dir = "/".join(fastq["path"].split("_R")[0:-1])
         for compare in fastqs[i + 1 :]:
-            compare_dir = "/".join(compare["path"].split("/")[0:-1])
+            compare_dir = "/".join(compare["path"].split("_R")[0:-1])
             if dir == compare_dir:
                 # check if R1 and R2 are present
                 r_check = set([fastq["metadata"]["R"], compare["metadata"]["R"]])

--- a/runner/operator/helper.py
+++ b/runner/operator/helper.py
@@ -145,7 +145,6 @@ def init_metadata():
     return metadata
 
 
-
 def pair_samples(fastqs):
     """
     pair sample fastqs based on the delivery directory.

--- a/runner/operator/helper.py
+++ b/runner/operator/helper.py
@@ -143,3 +143,37 @@ def init_metadata():
     metadata["runId"] = ""
     metadata["preservation"] = ""
     return metadata
+
+
+
+def pair_samples(fastqs):
+    """
+    pair sample fastqs based on the delivery directory.
+
+    Parameters:
+        fastqs (list): A list of sample fastq files.
+
+    Returns:
+        list: A list of tuples containing paired fastqs for a sample
+    """
+    sample_pairs = []
+    expected_pair = set(["R1", "R2"])
+    # match R1 and R2 based on delivery directory
+    # sorting on file names is not enough as they are non-unique
+    for i, fastq in enumerate(fastqs):
+        dir = "/".join(fastq["path"].split("_R")[0:-1])
+        for compare in fastqs[i + 1 :]:
+            compare_dir = "/".join(compare["path"].split("_R")[0:-1])
+            if dir == compare_dir:
+                # check if R1 and R2 are present
+                r_check = set([fastq["metadata"]["R"], compare["metadata"]["R"]])
+                if r_check.issubset(expected_pair):
+                    # Keep ordering consistent
+                    if fastq["metadata"]["R"] == "R1":
+                        sample_pairs.append((fastq, compare))
+                    else:
+                        sample_pairs.append((compare, fastq))
+                else:
+                    sample_name = fastq["metadata"]["cmoSampleName"]
+                    raise Exception(f"Improper pairing for: {sample_name}")
+    return sample_pairs


### PR DESCRIPTION
- adding fastq path up to `_R` to find matching fastq for a sample. Otherwise fastq name / path is still not unique. 
- adding pairing function to operator `helpers.py`. Importing to all nucleo operators (heme, cmoch, access) 