### PR TITLE
Update access_nucleo_qc_agg.py

### DIFF
--- a/runner/operator/access/v2_1_0/qc_agg/access_nucleo_qc_agg.py
+++ b/runner/operator/access/v2_1_0/qc_agg/access_nucleo_qc_agg.py
@@ -96,7 +96,7 @@ class AccessV2NucleoQcAggOperator(Operator):
         input = self.construct_sample_input(most_recent_runs_for_request)
         sample_list = []
         for single_run in most_recent_runs_for_request:
-            sample_list.append(single_run.output_metadata[settings.CMO_SAMPLE_NAME_METADATA_KEY])
+            sample_list.append(single_run.output_metadata["cmoSampleId"])
         return input, sample_list
 
     def process_listing(self, listing, name):

--- a/runner/operator/access/v2_1_0/qc_agg/access_nucleo_qc_agg.py
+++ b/runner/operator/access/v2_1_0/qc_agg/access_nucleo_qc_agg.py
@@ -96,7 +96,7 @@ class AccessV2NucleoQcAggOperator(Operator):
         input = self.construct_sample_input(most_recent_runs_for_request)
         sample_list = []
         for single_run in most_recent_runs_for_request:
-            sample_list.append(single_run.output_metadata["cmoSampleId"])
+            sample_list.append(single_run.tags['cmoSampleId'][0])
         return input, sample_list
 
     def process_listing(self, listing, name):

--- a/runner/operator/access/v2_1_0/qc_agg/access_nucleo_qc_agg.py
+++ b/runner/operator/access/v2_1_0/qc_agg/access_nucleo_qc_agg.py
@@ -96,7 +96,7 @@ class AccessV2NucleoQcAggOperator(Operator):
         input = self.construct_sample_input(most_recent_runs_for_request)
         sample_list = []
         for single_run in most_recent_runs_for_request:
-            sample_list.append(single_run.tags['cmoSampleId'][0])
+            sample_list.append(single_run.tags["cmoSampleId"][0])
         return input, sample_list
 
     def process_listing(self, listing, name):


### PR DESCRIPTION
"cmoSampleId" is being used to tag v2 runs instead of "cmoSampleName", causing the operator to fail.

This is something the should probably be corrected for future requests. 