### PR TITLE
Enable Token authentication in beagle

### DIFF
--- a/beagle/settings.py
+++ b/beagle/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     "import_export",
     "rangefilter",
     "rest_framework",
+    "rest_framework.authtoken",
     "corsheaders",
     "drf_multiple_model",
     "drf_yasg",
@@ -229,6 +230,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework_simplejwt.authentication.JWTAuthentication",
         "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
         "rest_framework.authentication.BasicAuthentication",
     ),
 }


### PR DESCRIPTION
## Changelog
- Enable Auth Token:
- Example:
  - Create token for user https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication
  - Add header ```Authorization: Token <token>```