### PR TITLE
template fix for only_normal_samples_event

### DIFF
--- a/notifier/events/only_normal_samples_event.py
+++ b/notifier/events/only_normal_samples_event.py
@@ -17,6 +17,6 @@ class OnlyNormalSamplesEvent(Event):
 
     def __str__(self):
         TEMPLATE = """
-        {cc}. Request {request_id} contains only normal samples.
+        Request {request_id} contains only normal samples.
         """
         return TEMPLATE.format(request_id=self.request_id)


### PR DESCRIPTION
`cc` still present in template for an only_normal_samples_event, causing the following error:
```
raised unexpected: KeyError('cc')
Traceback (most recent call last):
  File "/srv/services/beagle/code/beagle/notifier/event_handler/event_handler.py", line 19, in process
    self.logger.debug("[%s]: %s", e.get_type(), str(e))
  File "/srv/services/beagle/code/beagle/notifier/events/only_normal_samples_event.py", line 22, in __str__
    return TEMPLATE.format(request_id=self.request_id)
KeyError: 'cc'
```