### PR TITLE
Fix null sample_origin handling in pooled normal retrieval for argos operator v2_3_0

### DIFF
--- a/runner/operator/argos_operator/v2_3_0/argos_operator.py
+++ b/runner/operator/argos_operator/v2_3_0/argos_operator.py
@@ -250,7 +250,7 @@ class ArgosOperator(Operator):
                 tumor_current = tumor.first()
                 bait_set = tumor_current.metadata["baitSet"]
                 preservation_types = tumor_current.metadata["preservation"]
-                sample_origin = tumor_current.metadata["sampleOrigin"]
+                sample_origin = tumor_current.metadata.get("sampleOrigin") or ""
                 pooled_normal_files, bait_set_reformatted, sample_name = get_pooled_normal_files(
                     run_ids, preservation_types, bait_set, sample_origin
                 )

--- a/runner/operator/argos_operator/v2_3_0/bin/make_sample.py
+++ b/runner/operator/argos_operator/v2_3_0/bin/make_sample.py
@@ -144,7 +144,7 @@ def build_sample(data, ignore_sample_formatting=False):
         bait_set = meta["baitSet"]
         tumor_type = meta["tumorOrNormal"]
         specimen_type = meta[settings.SAMPLE_CLASS_METADATA_KEY]
-        sample_origin = meta["sampleOrigin"]
+        sample_origin = meta.get("sampleOrigin", "")
         species = meta["species"]
         cmo_sample_name = format_sample_name(
             meta[settings.CMO_SAMPLE_NAME_METADATA_KEY], specimen_type, ignore_sample_formatting

--- a/runner/operator/argos_operator/v2_3_0/bin/make_sample.py
+++ b/runner/operator/argos_operator/v2_3_0/bin/make_sample.py
@@ -144,7 +144,7 @@ def build_sample(data, ignore_sample_formatting=False):
         bait_set = meta["baitSet"]
         tumor_type = meta["tumorOrNormal"]
         specimen_type = meta[settings.SAMPLE_CLASS_METADATA_KEY]
-        sample_origin = meta.get("sampleOrigin", "")
+        sample_origin = meta.get("sampleOrigin") or ""
         species = meta["species"]
         cmo_sample_name = format_sample_name(
             meta[settings.CMO_SAMPLE_NAME_METADATA_KEY], specimen_type, ignore_sample_formatting

--- a/runner/operator/argos_operator/v2_3_0/bin/retrieve_samples_by_query.py
+++ b/runner/operator/argos_operator/v2_3_0/bin/retrieve_samples_by_query.py
@@ -92,7 +92,7 @@ def get_descriptor(bait_set, pooled_normals, preservation_types, run_ids, sample
 
         # sample_name is FROZENPOOLEDNORMAL unless FFPE is in any of the preservation types
         # in preservation_types; plc = preservations lower case
-        plc = set([x.lower() for x in preservation_types])
+        plc = set([x.lower() for x in preservation_types if x])  # filter out None/empty values
         run_ids_suffix_list = [i for i in run_ids if i]  # remove empty or false string values
         run_ids_suffix = "_".join(set(run_ids_suffix_list))
         sample_name = "FROZENPOOLEDNORMAL_" + run_ids_suffix
@@ -156,8 +156,8 @@ def get_preservation_type(preservation_types, sample_origin):
         - if preservation_type is not empty:
             - return 'ffpe' if is_ffpe(); otherwise 'frozen'
     """
-    plc = set([x.lower() for x in preservation_types])  # preservation lower case
-    solc = set([x.lower() for x in sample_origin])  # sample origin lower case
+    plc = set([x.lower() for x in preservation_types if x])  # preservation lower case
+    solc = set([x.lower() for x in sample_origin if x])  # sample origin lower case
     preservation = ""
 
     if not is_list_empty(plc) and not is_list_empty(solc):
@@ -233,7 +233,7 @@ def build_preservation_query(data):
 
     Main logic: if FFPE in data, return FFPE query; else, return FROZEN query
     """
-    plc = set([x.lower() for x in data])
+    plc = set([x.lower() for x in data if x])  # filter out None/empty values
     value = "FROZEN"
     if "ffpe" in plc:
         value = "FFPE"


### PR DESCRIPTION
## Summary
- Restore null/empty guards for `sample_origin` and `preservation_types` that were dropped during the v2_2_0 → v2_3_0 migration, causing crashes when `sampleOrigin` metadata is null
- Use safe accessor patterns (`meta.get()`, `if x` filters) to match the defensive behavior of v2_2_0
## Problem
When a sample's `sampleOrigin` metadata field is `null`, pooled normal retrieval in v2_3_0 crashes with either:
- `TypeError: 'NoneType' object is not iterable` — when `sample_origin` is `None` and iterated directly
- `AttributeError: 'NoneType' object has no attribute 'lower'` — when a list contains `None` and `.lower()` is called on it
This did not occur in v2_2_0 because that version used `meta.get("sampleOrigin", "")` and had `if x` guards in list comprehensions that filtered out null/empty values before calling `.lower()`.
## Changes
| File | Change |
|------|--------|
| `bin/make_sample.py` | `meta["sampleOrigin"]` → `meta.get("sampleOrigin", "")` |
| `bin/retrieve_samples_by_query.py` | Restored `if x` null guards in `get_preservation_type`, `build_preservation_query`, and `get_descriptor` |
| `argos_operator.py` | `tumor_current.metadata["sampleOrigin"]` → `tumor_current.metadata.get("sampleOrigin") or ""` in `get_files_for_pairs` |